### PR TITLE
[AA-977] Admin App Installer should use ToolsPath parameter to reference tools

### DIFF
--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -243,7 +243,7 @@ function Invoke-DbDeploy {
         [AllowEmptyCollection()]
         $Features = @(),
 
-        [string] $ToolsPath
+        [string] $ToolsPath = @{ "Invoke-Command:ScriptBlock"={{Get-ToolsPath}} }
     )
 
     $databaseIdLookup = @{
@@ -256,11 +256,7 @@ function Invoke-DbDeploy {
     }
     $databaseType = $databaseIdLookup[$Database]
 
-    $toolsPath = $ToolsPath
-
-    if([string]::IsNullOrEmpty($ToolsPath)){ $toolsPath = Get-ToolsPath }
-
-    $tool = (Join-Path $toolsPath 'EdFi.Db.Deploy')
+    $tool = (Join-Path $ToolsPath 'EdFi.Db.Deploy')
 
     $hasFeatures = ($Features.count -gt 0)
     if ($hasFeatures) {

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -256,7 +256,11 @@ function Invoke-DbDeploy {
     }
     $databaseType = $databaseIdLookup[$Database]
 
-    $tool = (Join-Path (Get-ToolsPath) 'EdFi.Db.Deploy')
+    $toolsPath = $ToolsPath
+
+    if([string]::IsNullOrEmpty($ToolsPath)){ $toolsPath = Get-ToolsPath }
+
+    $tool = (Join-Path $toolsPath 'EdFi.Db.Deploy')
 
     $hasFeatures = ($Features.count -gt 0)
     if ($hasFeatures) {

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -243,7 +243,7 @@ function Invoke-DbDeploy {
         [AllowEmptyCollection()]
         $Features = @(),
 
-        [string] $ToolsPath = @{ "Invoke-Command:ScriptBlock"={{Get-ToolsPath}} }
+        [string] $ToolsPath = (Get-ToolsPath)
     )
 
     $databaseIdLookup = @{


### PR DESCRIPTION
Looking to get feedback on the following change to ensure that the correct tools path is being used for DbDeploy tool.
**Background**
The AdminApp Installer uses the Invoke-DbDeploy function from logistics/scripts/modules/tools/ToolsHelper.psm1 in the Invoke-DbUpScripts function. Following is the snippet where it is used:
```
function Invoke-DbUpScripts {
    [CmdletBinding()]
    param (
        [hashtable]
        [Parameter(Mandatory=$true)]
        $Config
    )

    Invoke-Task -Name ($MyInvocation.MyCommand.Name) -Task {

        $adminConnectionString = Get-AdminInstallConnectionString $Config
        $engine = "PostgreSql"

        if(!(Test-IsPostgreSQL -Engine $Config.engine)){
            $engine = "SqlServer"
        }

        $params = @{
            Verb = "Deploy"
            Engine = $engine
            Database = "Admin"
            ConnectionString = $adminConnectionString
            FilePaths = $Config.WebApplicationPath
            ToolsPath = $Config.ToolsPath
        }

        Invoke-DbDeploy @params
    }
}
```
However, currently Invoke-DbDeploy function is not using the passed in $ToolsPath parameter to set the tools path. This causes a breaking change in the AdminApp installer during the Invoke-DbUpScripts task. This PR aims to use the passed in toolspath and use the Get-ToolsPath function only if the passed in argument is null/empty.
**Description**
Refactored Invoke-DbDeploy to use the passed in $ToolsPath parameter and use the Get-ToolsPath function only when $ToolsPath is empty or null