### PR TITLE
[ODS-4828] Sample data updates for 3.3.0-a 

### DIFF
--- a/logistics/scripts/configuration.packages.json
+++ b/logistics/scripts/configuration.packages.json
@@ -2,22 +2,22 @@
   "packages": {
     "EdFiMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template",
-      "PackageVersion": "5.2.0-b10540",
+      "PackageVersion": "5.2.0-b10548",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "GrandBend": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template",
-      "PackageVersion": "5.2.0-b10537",
+      "PackageVersion": "5.2.0-b10547",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL",
-      "PackageVersion": "5.2.0-b10510",
+      "PackageVersion": "5.2.0-b10520",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlPopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.PostgreSQL",
-      "PackageVersion": "5.2.0-b10501",
+      "PackageVersion": "5.2.0-b10512",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "homograph": {


### PR DESCRIPTION
Main builds are failing now  after Merge of ODS-4028 eventhough I had all green build at the time of merge. 

I am again updating the template builds to fix the build issues  .