### PR TITLE
[ODS-4871] Update Installers/NugetHelper to load release promoted packages by default

### DIFF
--- a/Application/EdFi.Ods.WebApi/log4net.config
+++ b/Application/EdFi.Ods.WebApi/log4net.config
@@ -23,8 +23,8 @@
     </layout>
   </appender>
   <appender name="AppInsightsAppender" type="Microsoft.ApplicationInsights.Log4NetAppender.ApplicationInsightsAppender, Microsoft.ApplicationInsights.Log4NetAppender">
+    <threshold value="WARN" />
     <layout type="log4net.Layout.PatternLayout">
-      <threshold value="WARN" />
       <conversionPattern value="%message%newline" />
     </layout>
   </appender>

--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
@@ -75,6 +75,10 @@ function Install-EdFiOdsSandboxAdmin {
         [string]
         $PackageVersion,
 
+        # NuGet package source . default value is set for release package source for installer .
+        [string]
+        $PackageSource = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi%40Release/nuget/v3/index.json",
+
         # Path for storing installation tools, e.g. nuget.exe. Default: "./tools".
         [string]
         $ToolsPath = "$PSScriptRoot/tools",
@@ -142,6 +146,7 @@ function Install-EdFiOdsSandboxAdmin {
         WebApplicationPath = $WebApplicationPath
         PackageName = $PackageName
         PackageVersion = $PackageVersion
+        PackageSource = $PackageSource
         ToolsPath = $ToolsPath
         DownloadPath = $DownloadPath
         WebSitePath = $WebSitePath
@@ -190,6 +195,7 @@ function Get-SandboxAdminPackage {
             PackageVersion = $Config.PackageVersion
             ToolsPath = $Config.ToolsPath
             OutputDirectory = $Config.DownloadPath
+            PackageSource = $Config.PackageSource
         }
         $packageDir = Get-NuGetPackage @parameters
         Test-Error

--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/test.ps1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/test.ps1
@@ -20,6 +20,15 @@ function Invoke-Install {
     Install-EdFiOdsSandboxAdmin @p
 }
 
+function Invoke-DifferentPackageSource {
+    $p = @{
+        OAuthUrl = "https://localhost/EdFiOdsWebApi"
+        PackageSource  = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+    }
+
+    Install-EdFiOdsSandboxAdmin @p
+}
+
 function Invoke-CustomPackage {
     $p = @{
         OAuthUrl = "https://localhost/EdFiOdsWebApi"
@@ -68,12 +77,15 @@ try {
     switch ($Scenario) {
         "Install" { Invoke-Install }
         "CustomPackage" { Invoke-CustomPackage }
+        "DifferentPackageSource" { Invoke-DifferentPackageSource }
         "Uninstall" { Invoke-Uninstall }
         "InstallCustomSettings" { Invoke-InstallCustomSettings }
         "UninstallCustomSettings" { Invoke-UninstallCustomSettings }
         default {
             Write-Host "Valid test scenarios are: "
             Write-Host "    Install"
+            Write-Host "    CustomPackage"
+            Write-Host "    DifferentPackageSource"
             Write-Host "    Uninstall"
             Write-Host "    InstallCustomSettings"
             Write-Host "    UninstallCustomSettings"

--- a/Scripts/NuGet/EdFi.Installer.SwaggerUI/Install-EdFiOdsSwaggerUI.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SwaggerUI/Install-EdFiOdsSwaggerUI.psm1
@@ -52,6 +52,10 @@ function Install-EdFiOdsSwaggerUI {
         [string]
         $PackageVersion,
 
+        # NuGet package source . default value is set for release package source for installer .
+        [string]
+        $PackageSource = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi%40Release/nuget/v3/index.json",
+
         # Path for storing installation tools, e.g. nuget.exe. Default: "./tools".
         [string]
         $ToolsPath = "$PSScriptRoot/tools",
@@ -117,6 +121,7 @@ function Install-EdFiOdsSwaggerUI {
         WebApplicationPath = $WebApplicationPath
         PackageName = $PackageName
         PackageVersion = $PackageVersion
+        PackageSource = $PackageSource
         ToolsPath = $ToolsPath
         DownloadPath = $DownloadPath
         WebSitePath = $WebSitePath
@@ -241,6 +246,7 @@ function Get-SwaggerPackage {
             PackageVersion = $Config.PackageVersion
             ToolsPath = $Config.ToolsPath
             OutputDirectory = $Config.DownloadPath
+            PackageSource = $Config.PackageSource
         }
         $packageDir = Get-NuGetPackage @parameters
 

--- a/Scripts/NuGet/EdFi.Installer.SwaggerUI/test.ps1
+++ b/Scripts/NuGet/EdFi.Installer.SwaggerUI/test.ps1
@@ -23,6 +23,17 @@ function Invoke-Install {
     Install-EdFiOdsSwaggerUI @p
 }
 
+function Invoke-DifferentPackageSource {
+    $p = @{
+        ToolsPath = "../../../tools"
+        WebApiMetadataUrl = "https://edfi-wrk118/EdFiOdsWebApi/metadata"
+        WebApiVersionUrl = "https://edfi-wrk118/EdFiOdsWebApi"
+        PackageSource  = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+    }
+
+    Install-EdFiOdsSwaggerUI @p
+}
+
 function Invoke-KeyAndSecret {
     $p = @{
         ToolsPath = "../../../tools"
@@ -58,11 +69,14 @@ function Invoke-Uninstall {
 try {
     switch ($Scenario) {
         "Install" { Invoke-Install }
+        "DifferentPackageSource" { Invoke-DifferentPackageSource }
         "KeyAndSecret" { Invoke-KeyAndSecret }
         "Uninstall" { Invoke-Uninstall }
         default {
             Write-Host "Valid test scenarios are: "
             Write-Host "    Install"
+            Write-Host "    DifferentPackageSource"
+            Write-Host "    KeyAndSecret"
             Write-Host "    Uninstall"
         }
     }

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -369,6 +369,7 @@ function Get-WebApiPackage {
             PackageVersion = $Config.PackageVersion
             ToolsPath = $Config.ToolsPath
             OutputDirectory = $Config.DownloadPath
+            PackageSource = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi%40Release/nuget/v3/index.json"
         }
         $packageDir = Get-NuGetPackage @parameters
         Test-Error

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -160,7 +160,11 @@ function Install-EdFiOdsWebApi {
         # NuGet package version. If not set, will retrieve the latest full release package.
         [string]
         $PackageVersion,
-        
+
+        # NuGet package source . default value is set for release package source for installer .
+        [string]
+        $PackageSource = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi%40Release/nuget/v3/index.json",
+                
         # Path for storing installation tools, e.g. nuget.exe. Default: "./tools".
         [string]
         $ToolsPath = "$PSScriptRoot/tools",
@@ -275,6 +279,7 @@ function Install-EdFiOdsWebApi {
         WebApplicationPath = $WebApplicationPath
         PackageName = $PackageName
         PackageVersion = $PackageVersion
+        PackageSource = $PackageSource
         ToolsPath = $ToolsPath
         DownloadPath = $DownloadPath
         WebSitePath = $WebSitePath
@@ -369,7 +374,7 @@ function Get-WebApiPackage {
             PackageVersion = $Config.PackageVersion
             ToolsPath = $Config.ToolsPath
             OutputDirectory = $Config.DownloadPath
-            PackageSource = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi%40Release/nuget/v3/index.json"
+            PackageSource = $Config.PackageSource
         }
         $packageDir = Get-NuGetPackage @parameters
         Test-Error

--- a/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
@@ -56,6 +56,7 @@ function Invoke-DifferentPackageSource {
         PackageSource  = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     }
     Install-EdFiOdsWebApi @p
+}
 
 function Invoke-SeparateConnectionInfo {
     $p = @{

--- a/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
@@ -141,15 +141,39 @@ function Invoke-FeatureOverride {
         WebApiFeatures = @{
             BearerTokenTimeoutMinutes="BearerTokenTimeoutMinutes"                                   
             ExcludedExtensionSources="GrandBend"
-            FeatureIsEnabled=@{
-                changeQueries = $true
-                openApiMetadata = $false
-                composites = $false
-                profiles = $false                
-                identityManagement = $false
-                extensions = $false
-                ownershipBasedAuthorization = $true
-                uniqueIdValidation = $true
+            Features= @{
+                "changeQueries"= @{
+                    Name= "changeQueries"
+                    IsEnabled= $true
+                    }
+				"OpenApiMetadata"= @{
+                    Name= "OpenApiMetadata"
+                    IsEnabled= $false
+                    }
+				"composites"= @{
+                    Name= "composites"
+                    IsEnabled= $false
+                    }
+				"profiles"= @{
+                    Name= "profiles"
+                    IsEnabled= $false
+                    }
+				"identityManagement"= @{
+                    Name= "identityManagement"
+                    IsEnabled= $false
+                    }
+				"extensions"= @{
+                    Name= "extensions"
+                    IsEnabled= $false
+                    }
+				"ownershipBasedAuthorization"= @{
+                    Name= "ownershipBasedAuthorization"
+                    IsEnabled= $true
+                    }
+				"uniqueIdValidation"= @{
+                    Name= "uniqueIdValidation"
+                    IsEnabled= $true
+                    }
             }
         }
     }

--- a/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
@@ -141,39 +141,15 @@ function Invoke-FeatureOverride {
         WebApiFeatures = @{
             BearerTokenTimeoutMinutes="BearerTokenTimeoutMinutes"                                   
             ExcludedExtensionSources="GrandBend"
-            Features= @{
-                "changeQueries"= @{
-                    Name= "changeQueries"
-                    IsEnabled= $true
-                    }
-				"OpenApiMetadata"= @{
-                    Name= "OpenApiMetadata"
-                    IsEnabled= $false
-                    }
-				"composites"= @{
-                    Name= "composites"
-                    IsEnabled= $false
-                    }
-				"profiles"= @{
-                    Name= "profiles"
-                    IsEnabled= $false
-                    }
-				"identityManagement"= @{
-                    Name= "identityManagement"
-                    IsEnabled= $false
-                    }
-				"extensions"= @{
-                    Name= "extensions"
-                    IsEnabled= $false
-                    }
-				"ownershipBasedAuthorization"= @{
-                    Name= "ownershipBasedAuthorization"
-                    IsEnabled= $true
-                    }
-				"uniqueIdValidation"= @{
-                    Name= "uniqueIdValidation"
-                    IsEnabled= $true
-                    }
+            FeatureIsEnabled=@{
+                changeQueries = $true
+                openApiMetadata = $false
+                composites = $false
+                profiles = $false                
+                identityManagement = $false
+                extensions = $false
+                ownershipBasedAuthorization = $true
+                uniqueIdValidation = $true
             }
         }
     }

--- a/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
@@ -53,8 +53,6 @@ function Invoke-DifferentPackageSource {
             Server="localhost"
             UseIntegratedSecurity=$true
         }
-        PackageName = "EdFi.Suite3.Ods.WebApi"
-        PackageVersion = "5.2.14321"
         PackageSource  = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     }
     Install-EdFiOdsWebApi @p
@@ -191,6 +189,7 @@ try {
         "Sandbox" { Invoke-Sandbox }
         default { 
             Write-Host "Valid test scenarios are: "
+            Write-Host "    DifferentPackageSource"
             Write-Host "    SeparateConnectionInfo"
             Write-Host "    CommonConnectionInfo"
             Write-Host "    FeatureOverride"

--- a/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
@@ -44,6 +44,21 @@ function Invoke-NonDefaultApplication {
     Install-EdFiOdsWebApi @p
 }
 
+function Invoke-DifferentPackageSource {
+    $p = @{
+        ToolsPath = "../../../tools"
+        InstallType = "SharedInstance"
+        DbConnectionInfo = @{
+            Engine="SqlServer"
+            Server="localhost"
+            UseIntegratedSecurity=$true
+        }
+        PackageName = "EdFi.Suite3.Ods.WebApi"
+        PackageVersion = "5.2.14321"
+        PackageSource  = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+    }
+    Install-EdFiOdsWebApi @p
+
 function Invoke-SeparateConnectionInfo {
     $p = @{
         ToolsPath = "../../../tools"
@@ -164,6 +179,7 @@ function Invoke-UninstallDifferentWebSite {
 
 try {
     switch ($Scenario) {
+        "DifferentPackageSource" { Invoke-DifferentPackageSource } 
         "SeparateConnectionInfo" { Invoke-SeparateConnectionInfo } 
         "CommonConnectionInfo" { Invoke-CommonConnectionInfo }
         "FeatureOverride" { Invoke-FeatureOverride }

--- a/Scripts/NuGet/prep-installer-package.ps1
+++ b/Scripts/NuGet/prep-installer-package.ps1
@@ -15,7 +15,7 @@ $ErrorActionPreference = "Stop"
 Push-Location $PackageDirectory
 
 $dependencyVersions = @{
-    AppCommon = "1.4.0"
+    AppCommon = "1.4.1170"
 }
 
 $edFiRepoContainer = "$PackageDirectory/../../../.."

--- a/logistics/scripts/modules/packaging/nuget-helper.psm1
+++ b/logistics/scripts/modules/packaging/nuget-helper.psm1
@@ -101,38 +101,20 @@ function Get-NuGetPackage {
     )
 
     $nuget = Install-NuGetCli $ToolsPath
-
-    if (-not $PackageVersion) {
-        # Lookup current "latest" version
-        $latestVersion = & "$ToolsPath\nuget" list -source $PackageSource $PackageName
-        if ($latestVersion) {
-            # output is like "packageName packageVersion", split to get second part
-            $parts = $latestVersion.split(' ')
-            if ($parts.length -eq 2) {
-                $PackageVersion = $parts[1]
-            }
-        }
-    }
-
-    $downloadedPackagePath = Join-Path $OutputDirectory "$PackageName.$PackageVersion"
-
-    if (Test-Path $downloadedPackagePath) {
-        Write-Debug "Reusing already downloaded package for: $PackageName"
-
-        return $downloadedPackagePath
-    }
-
     $parameters = @(
         "install", $PackageName,
         "-source", $PackageSource,
-        "-version", $PackageVersion,
         "-outputDirectory", $OutputDirectory
     )
-
+    if ($PackageVersion) {
+        $parameters += "-version"
+        $parameters += $PackageVersion
+    }
+    
     Write-Host -ForegroundColor Magenta "$ToolsPath\nuget $parameters"
     & "$ToolsPath\nuget" $parameters | Out-Null
 
-    return Resolve-Path $downloadedPackagePath
+    return Resolve-Path $outputDirectory/$PackageName.$PackageVersion* | Select-Object -Last 1
 }
 
 $exports = @(


### PR DESCRIPTION
$parameters = @{
    DbConnectionInfo = @{
        Engine="SqlServer"
        Server="localhost"
        UseIntegratedSecurity=$true
    }
    InstallType = "Sandbox"
    WebApiFeatures = @{
            BearerTokenTimeoutMinutes="BearerTokenTimeoutMinutes"                                  
            ExcludedExtensionSources="GrandBend"
			Features= @{
                "changeQueries"= @{
                    Name= "changeQueries"
                    IsEnabled= $true
                    }
				"OpenApiMetadata"= @{
                    Name= "OpenApiMetadata"
                    IsEnabled= $false
                    }
				"composites"= @{
                    Name= "composites"
                    IsEnabled= $false
                    }
				"profiles"= @{
                    Name= "profiles"
                    IsEnabled= $false
                    }
				"identityManagement"= @{
                    Name= "identityManagement"
                    IsEnabled= $false
                    }
				"extensions"= @{
                    Name= "extensions"
                    IsEnabled= $false
                    }
				"ownershipBasedAuthorization"= @{
                    Name= "ownershipBasedAuthorization"
                    IsEnabled= $false
                    }
				"uniqueIdValidation"= @{
                    Name= "uniqueIdValidation"
                    IsEnabled= $false
                    }
            }
	}     
}