### PR TITLE
[ODS-4874] WebAPI installer does not enable any features 

### DIFF
--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -390,12 +390,18 @@ function Invoke-TransformWebConfigAppSettings {
             $settings = Get-Content $settingsFile | ConvertFrom-Json | ConvertTo-Hashtable
             $settings.ApiSettings.Mode = $Config.InstallType
             $settings.ApiSettings.Engine = $Config.engine
-            $settings.ApiSettings.Features=$Config.WebApiFeatures.Features
-            $settings.ApiSettings.BearerTokenTimeoutMinutes=$Config.WebApiFeatures.BearerTokenTimeoutMinutes
-            $settings.ApiSettings.ExcludedExtensions=$Config.WebApiFeatures.ExcludedExtensions
-            $EmptyHashTable=@{}
-            $mergedSettings = Merge-Hashtables $settings, $EmptyHashTable
-            New-JsonFile $settingsFile $mergedSettings -Overwrite
+            If ($Config.WebApiFeatures.Features -ne $Null) {
+                foreach ($feature in $Config.WebApiFeatures.Features) {
+                    foreach ($defaultfeature in $settings.ApiSettings.Features) {
+                        If ( $feature.Name -eq $defaultfeature.Name) {
+                            $defaultfeature.IsEnabled =$feature.IsEnabled
+                        }
+                    }
+                }
+            }
+           $settings.ApiSettings.BearerTokenTimeoutMinutes=$Config.WebApiFeatures.BearerTokenTimeoutMinutes
+           $settings.ApiSettings.ExcludedExtensions=$Config.WebApiFeatures.ExcludedExtensions
+           New-JsonFile $settingsFile $settings -Overwrite
         }
 }
 

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -134,18 +134,18 @@ function Install-EdFiOdsWebApi {
             WebApiFeatures = @{
                 BearerTokenTimeoutMinutes="23"
                 ExcludedExtensions=@{}
-                Features= @{
-                "OpenApiMetadata"= @{
-                    Name= "OpenApiMetadata"
-                    IsEnabled= $true
+                Features= @(               
+				    @{
+                        Name= "OpenApiMetadata"
+                        IsEnabled= $true
+                    },
+				    @{
+                        Name= "AggregateDependencies"
+                        IsEnabled= $true
                     }
-                "AggregateDependencies"=@{
-                     Name= "AggregateDependencies"
-                    IsEnabled= $true
-                     }
-                    }
-                }
-             }
+                )
+            }
+        }
         PS c:\> Install-EdFiOdsWebApi @parameters
 
         Install in the default mode (shared) instance with basic database

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -399,7 +399,7 @@ function Invoke-TransformWebConfigAppSettings {
                     }
                 }
             }
-           $settings.ApiSettings.BearerTokenTimeoutMinutes=$Config.WebApiFeatures.BearerTokenTimeoutMinutes
+           $settings.BearerTokenTimeoutMinutes=$Config.WebApiFeatures.BearerTokenTimeoutMinutes
            $settings.ApiSettings.ExcludedExtensions=$Config.WebApiFeatures.ExcludedExtensions
            New-JsonFile $settingsFile $settings -Overwrite
         }

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -134,12 +134,12 @@ function Install-EdFiOdsWebApi {
             WebApiFeatures = @{
                 BearerTokenTimeoutMinutes="23"
                 ExcludedExtensions=@{}
-                Features= @(               
-				    @{
+                Features= @(   
+                    @{
                         Name= "OpenApiMetadata"
                         IsEnabled= $true
                     },
-				    @{
+                    @{
                         Name= "AggregateDependencies"
                         IsEnabled= $true
                     }

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -134,7 +134,7 @@ function Install-EdFiOdsWebApi {
             WebApiFeatures = @{
                 BearerTokenTimeoutMinutes="23"
                 ExcludedExtensions=@{}
-                Features= @(   
+                Features= @(
                     @{
                         Name= "OpenApiMetadata"
                         IsEnabled= $true


### PR DESCRIPTION
$parameters = @{
      DbConnectionInfo = @{
        Engine="SqlServer"
        Server="localhost"
        UseIntegratedSecurity=$true
    }
    InstallType = "Sandbox"
    WebApiFeatures = @{
            BearerTokenTimeoutMinutes="BearerTokenTimeoutMinutes"                                   
            ExcludedExtensionSources="GrandBend"
            Features= @(
                @{
                    Name= "changeQueries"
                    IsEnabled= $true
                    },
				@{
                    Name= "OpenApiMetadata"
                    IsEnabled= $true
                 },
				@{
                    Name= "composites"
                    IsEnabled= $true
                 },
				 @{
                    Name= "profiles"
                    IsEnabled= $true
                 },
				 @{
                    Name= "identityManagement"
                    IsEnabled= $true
                    },
				 @{
                    Name= "extensions"
                    IsEnabled= $true
                    },
				@{
                    Name= "ownershipBasedAuthorization"
                    IsEnabled= $true
                    },
				@{
                    Name= "uniqueIdValidation"
                    IsEnabled= $true
                 }
           )
     }      
}