### PR TITLE
[AA-1101] Updated installers to use common modules from AppCommon package and team city update to build platform packages with latest app common

### DIFF
--- a/Scripts/NuGet/.gitignore
+++ b/Scripts/NuGet/.gitignore
@@ -1,5 +1,6 @@
 Ed-Fi-Common/
 Ed-Fi-ODS/
 Ed-Fi-ODS-Implementation/
+AppCommon/
 tools/
 *.log

--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/EdFi.Installer.SandboxAdmin.nuspec
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/EdFi.Installer.SandboxAdmin.nuspec
@@ -13,9 +13,7 @@
   </metadata>
   <files>
     <file src="Install-EdFiOdsSandboxAdmin.psm1" />
-    <file src="Ed-Fi-Common/**" />
-    <file src="Ed-Fi-ODS/**" />
-    <file src="Ed-Fi-ODS-Implementation/**" />
+    <file src="AppCommon/**" /> 
     <file src="../../../LICENSE.txt" />
     <file src="../../../NOTICES.md" />
   </files>

--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
@@ -11,13 +11,15 @@ To run manually from source code, instead of from an expanded NuGet package,
 run the prep-installer-package.ps1 script first. Think of it as a "restore-packages"
 step before compiling in C#.
 #>
-Import-Module -Force -Global "$PSScriptRoot/Ed-Fi-ODS-Implementation/logistics/scripts/modules/path-resolver.psm1"
-Import-Module -Force -Global "$PSScriptRoot/Ed-Fi-ODS-Implementation/logistics/scripts/modules/utility/hashtable.psm1"
-Import-Module -Force -Global "$PSScriptRoot/Ed-Fi-ODS-Implementation/logistics/scripts/modules/packaging/nuget-helper.psm1"
-Import-Module -Force -Global "$PSScriptRoot/Ed-Fi-ODS-Implementation/logistics/scripts/modules/tasks/TaskHelper.psm1"
-Import-Module -Force -Global "$PSScriptRoot/Ed-Fi-ODS-Implementation/logistics/scripts/modules/Application/Install.psm1"
-Import-Module -Force -Global "$PSScriptRoot/Ed-Fi-ODS-Implementation/logistics/scripts/modules/Application/Uninstall.psm1"
-Import-Module -Force -Global "$PSScriptRoot/Ed-Fi-ODS-Implementation/logistics/scripts/modules/Application/Configuration.psm1"
+
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Utility/hashtable.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Utility/nuget-helper.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Utility/TaskHelper.psm1
+
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Application/Install.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Application/Uninstall.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Application/Configuration.psm1
+
 
 function Install-EdFiOdsSandboxAdmin {
     <#

--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/build-package.ps1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/build-package.ps1
@@ -25,7 +25,7 @@ param (
     $NuGetApiKey,
 
     [string]
-    $AppCommonVersion = "1.4.0-pre1183"
+    $AppCommonVersion = "2.0.0"
 )
 $ErrorActionPreference = "Stop"
 

--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/build-package.ps1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/build-package.ps1
@@ -22,11 +22,14 @@ param (
     $NuGetFeed,
 
     [string]
-    $NuGetApiKey
+    $NuGetApiKey,
+
+    [string]
+    $AppCommonVersion = "1.4.0-pre1183"
 )
 $ErrorActionPreference = "Stop"
 
-Invoke-Expression "$PSScriptRoot/../prep-installer-package.ps1 $PSScriptRoot"
+Invoke-Expression "$PSScriptRoot/../prep-installer-package.ps1 $PSScriptRoot $AppCommonVersion"
 
 $verbose = $PSCmdlet.MyInvocation.BoundParameters["Verbose"]
 

--- a/Scripts/NuGet/EdFi.Installer.SwaggerUI/EdFi.Installer.SwaggerUI.nuspec
+++ b/Scripts/NuGet/EdFi.Installer.SwaggerUI/EdFi.Installer.SwaggerUI.nuspec
@@ -12,10 +12,8 @@
     <license type="file">LICENSE.txt</license>
   </metadata>
   <files>
-    <file src="Install-EdFiOdsSwaggerUI.psm1" target="" />
-    <file src="Ed-Fi-Common/**" />
-    <file src="Ed-Fi-ODS/**" />
-    <file src="Ed-Fi-ODS-Implementation/**" />
+    <file src="Install-EdFiOdsSwaggerUI.psm1" target="" /> 
+    <file src="AppCommon/**" /> 
     <file src="../../../LICENSE.txt" />
     <file src="../../../NOTICES.md" />
   </files>

--- a/Scripts/NuGet/EdFi.Installer.SwaggerUI/Install-EdFiOdsSwaggerUI.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SwaggerUI/Install-EdFiOdsSwaggerUI.psm1
@@ -12,15 +12,14 @@ run the prep-installer-package.ps1 script first. Think of it as a "restore-packa
 step before compiling in C#.
 #>
 
-Import-Module -Force -Scope Global "$PSScriptRoot/Ed-Fi-ODS-Implementation/logistics/scripts/modules/path-resolver.psm1"
-Import-Module -Force -Scope Global $folders.modules.invoke("utility/hashtable.psm1")
-Import-Module -Force -Scope Global $folders.modules.invoke("packaging/nuget-helper.psm1")
-Import-Module -Force -Scope Global $folders.modules.invoke("tasks/TaskHelper.psm1")
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Utility/hashtable.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Utility/nuget-helper.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Utility/TaskHelper.psm1
 
 # Import the following with global  scope so that they are available inside of script blocks
-Import-Module -Force -Scope Global $folders.modules.invoke("Application/Install.psm1")
-Import-Module -Force -Scope Global $folders.modules.invoke("Application/Uninstall.psm1")
-Import-Module -Force -Scope Global $folders.modules.invoke("Application/Configuration.psm1")
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Application/Install.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Application/Uninstall.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Application/Configuration.psm1
 
 function Install-EdFiOdsSwaggerUI {
     <#

--- a/Scripts/NuGet/EdFi.Installer.SwaggerUI/build-package.ps1
+++ b/Scripts/NuGet/EdFi.Installer.SwaggerUI/build-package.ps1
@@ -25,7 +25,7 @@ param (
     $NuGetApiKey,
 
     [string]
-    $AppCommonVersion = "1.4.0-pre1183"
+    $AppCommonVersion = "2.0.0"
 )
 $ErrorActionPreference = "Stop"
 

--- a/Scripts/NuGet/EdFi.Installer.SwaggerUI/build-package.ps1
+++ b/Scripts/NuGet/EdFi.Installer.SwaggerUI/build-package.ps1
@@ -22,11 +22,14 @@ param (
     $NuGetFeed,
 
     [string]
-    $NuGetApiKey
+    $NuGetApiKey,
+
+    [string]
+    $AppCommonVersion = "1.4.0-pre1183"
 )
 $ErrorActionPreference = "Stop"
 
-Invoke-Expression "$PSScriptRoot/../prep-installer-package.ps1 $PSScriptRoot"
+Invoke-Expression "$PSScriptRoot/../prep-installer-package.ps1 $PSScriptRoot $AppCommonVersion"
 
 $verbose = $PSCmdlet.MyInvocation.BoundParameters["Verbose"]
 

--- a/Scripts/NuGet/EdFi.Installer.WebApi/EdFi.Installer.WebApi.nuspec
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/EdFi.Installer.WebApi.nuspec
@@ -12,10 +12,8 @@
     <license type="file">LICENSE.txt</license>
   </metadata>
   <files>
-    <file src="Install-EdFiOdsWebApi.psm1" />
-    <file src="Ed-Fi-Common/**" />
-    <file src="Ed-Fi-ODS/**" />
-    <file src="Ed-Fi-ODS-Implementation/**" />
+    <file src="Install-EdFiOdsWebApi.psm1" />  
+    <file src="AppCommon/**" />
     <file src="../../../LICENSE.txt" />
     <file src="../../../NOTICES.md" />
   </files>

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -12,15 +12,13 @@ run the prep-installer-package.ps1 script first. Think of it as a "restore-packa
 step before compiling in C#.
 #>
 
-Import-Module -Force -Scope Global "$PSScriptRoot/Ed-Fi-ODS-Implementation/logistics/scripts/modules/path-resolver.psm1"
-Import-Module -Force -Scope Global $folders.modules.invoke("utility/hashtable.psm1")
-Import-Module -Force -Scope Global $folders.modules.invoke("packaging/nuget-helper.psm1")
-Import-Module -Force -Scope Global $folders.modules.invoke("tasks/TaskHelper.psm1")
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Utility/hashtable.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Utility/nuget-helper.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Utility/TaskHelper.psm1
 
-# Import the following with global scope so that they are available inside of script blocks
-Import-Module -Force -Scope Global $folders.modules.invoke("Application/Install.psm1")
-Import-Module -Force -Scope Global $folders.modules.invoke("Application/Uninstall.psm1")
-Import-Module -Force -Scope Global $folders.modules.invoke("Application/Configuration.psm1")
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Application/Install.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Application/Uninstall.psm1
+Import-Module -Force -Scope Global $PSScriptRoot/AppCommon/Application/Configuration.psm1
 
 function Install-EdFiOdsWebApi {
     <#

--- a/Scripts/NuGet/EdFi.Installer.WebApi/build-package.ps1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/build-package.ps1
@@ -22,11 +22,15 @@ param (
     $NuGetFeed,
 
     [string]
-    $NuGetApiKey
+    $NuGetApiKey,
+
+    [string]
+    $AppCommonVersion = "1.4.0-pre1183"
+     
 )
 $ErrorActionPreference = "Stop"
 
-Invoke-Expression "$PSScriptRoot/../prep-installer-package.ps1 $PSScriptRoot"
+Invoke-Expression "$PSScriptRoot/../prep-installer-package.ps1 $PSScriptRoot $AppCommonVersion"
 
 $verbose = $PSCmdlet.MyInvocation.BoundParameters["Verbose"]
 

--- a/Scripts/NuGet/EdFi.Installer.WebApi/build-package.ps1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/build-package.ps1
@@ -25,7 +25,7 @@ param (
     $NuGetApiKey,
 
     [string]
-    $AppCommonVersion = "1.4.0-pre1183"
+    $AppCommonVersion = "2.0.0"
      
 )
 $ErrorActionPreference = "Stop"

--- a/Scripts/NuGet/prep-installer-package.ps1
+++ b/Scripts/NuGet/prep-installer-package.ps1
@@ -8,15 +8,14 @@
 param (
     [string]
     [Parameter(Mandatory = $true)]
-    $PackageDirectory
+    $PackageDirectory,
+
+    [string]
+    $AppCommonVersion 
 )
 $ErrorActionPreference = "Stop"
 
 Push-Location $PackageDirectory
-
-$dependencyVersions = @{
-    AppCommon = "1.4.0-pre1176"
-}
 
 $edFiRepoContainer = "$PackageDirectory/../../../.."
 $repositoryNames = @('Ed-Fi-ODS-Implementation')
@@ -26,32 +25,11 @@ Import-Module -Force $folders.modules.invoke("packaging/nuget-helper.psm1")
 # Download App Common
 $parameters = @{
     PackageName = "EdFi.Installer.AppCommon"
-    PackageVersion = $dependencyVersions.AppCommon
+    PackageVersion = $AppCommonVersion
     ToolsPath = "../../../tools"
 }
 $appCommonDirectory = Get-NuGetPackage @parameters
 
-# Copy Ed-Fi-XYZ folders from App Common folder to current
-@(
-    "Ed-Fi-ODS"
-    "Ed-Fi-ODS-Implementation"
-) | ForEach-Object {
-    Copy-Item -Recurse -Path $appCommonDirectory/$_ -Destination $PackageDirectory -Force
-}
-
-# Move AppCommon's modules into Ed-Fi-ODS-Implementation so that they are discoverable with pathresolver
-@(
-    "Application"
-    "Environment"
-    "IIS"
-) | ForEach-Object {
-    $parameters = @{
-        Recurse = $true
-        Force = $true
-        Path = "$appCommonDirectory/$_"
-        Destination = "$PackageDirectory/Ed-Fi-ODS-Implementation/logistics/scripts/modules"
-    }
-    Copy-Item @parameters
-}
+Copy-Item -Path $appCommonDirectory -Destination $PackageDirectory/AppCommon -recurse -Force
 
 Pop-Location


### PR DESCRIPTION
@vimayya @stephenfuqua @saa14 
Please help review the changes.
1. Updated installers to use common modules (hashtable. psm1, nuget-helper.psm1, TaskHelper.psm1, ToolsHelper.psm1) from AppCommon package.
2. Refactored all the module paths.
3. Added AppCommonVersion parameter on build-package to have value at the build time
4. Using prerelease version of AppCommon, will be updating to release version
Blocked by: https://github.com/Ed-Fi-Alliance/Ed-Fi-ODS-Deploy/pull/215/files
Thanks