### PR TITLE
ODS-5147 - Add TPDM namespace to sandbox admin install script

### DIFF
--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
@@ -234,6 +234,7 @@ function Get-DefaultCredentialSettings {
                 NamespacePrefixes = @(
                     "uri://ed-fi.org"
                     "uri://gbisd.edu"
+                    "uri://tpdm.ed-fi.org"
                 )
                 Sandboxes         = @{
                     "Populated Demonstration Sandbox" = @{


### PR DESCRIPTION
The TPDM namespace was missing from the function in the installer that generates the default appsettings, so when the Sandbox Admin was installed, this namespace was missing. Now this namespace has been added as part of the installer.

To test these changes what was done:

1. A new installer package was built on this branch and published to Azure, with a version of  5.3.7
![image](https://user-images.githubusercontent.com/1013553/140191258-c6412d3e-df4d-4d72-a741-27471243436a.png)

2. That installer package was downloaded and extracted
3. The package source was modified to remove it only looking for release versions of packages to ensure it would pull a 5.3 version of Sandbox Admin
4. The install was ran, and confirmed that it pulled 5.3.1102 of the Sandbox Admin package, which is the latest for v5.3

![image](https://user-images.githubusercontent.com/1013553/140190994-a4f48f73-86ae-4219-880a-7cea7dda8884.png)

And that in the folder where Sandbox Admin was installed, the appsettings.json now contained the tpdm namespace
![image](https://user-images.githubusercontent.com/1013553/140191129-342ab8a9-0f1e-44d1-9418-325bcbd03111.png)
