### PR TITLE
ODS-5149 - Set IntegratedSecurity based on being present in connection string for SandboxAdmin install

### DIFF
--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
@@ -332,8 +332,13 @@ function Convert-ConnectionStringtoDatabaseConnectionInfo {
     # using set_ConnectionString correctly uses the underlying C# setter functionality resulting in a dictionary of connection string properties
     $csb.set_ConnectionString($ConnectionString)
 
+    $useIntegratedSecurity = $false;
+    if($ConnectionString.Replace(" ","").ToLower().Contains("integratedsecurity=true")) {
+        $useIntegratedSecurity = $true
+    }
+    
     $dbConnectionInfo = @{
-        UseIntegratedSecurity = $true
+        UseIntegratedSecurity = $useIntegratedSecurity
         Engine                = $Config.MergedSettings.ApiSettings.Engine
     }
     if ($null -ne $csb.Server) { $dbConnectionInfo.Server = $csb.Server }

--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
@@ -211,10 +211,10 @@ function Get-DefaultConnectionStringsByEngine {
         }
         PostgreSQL = @{
             ConnectionStrings = @{
-                EdFi_Ods      = "Host=localhost; Port=5402; Username=postgres; Database=EdFi_{0}; Pooling=true; Minimum Pool Size=10; Maximum Pool Size=50; Application Name=EdFi.Ods.SandboxAdmin"
-                EdFi_Admin    = "Host=localhost; Port=5402; Username=postgres; Database=EdFi_Admin; Pooling=true; Minimum Pool Size=10; Maximum Pool Size=50; Application Name=EdFi.Ods.SandboxAdmin"
-                EdFi_Security = "Host=localhost; Port=5402; Username=postgres; Database=EdFi_Security; Pooling=true; Minimum Pool Size=10; Maximum Pool Size=50; Application Name=EdFi.Ods.SandboxAdmin"
-                EdFi_Master   = "Host=localhost; Port=5402; Username=postgres; Database=postgres; Pooling=false; Application Name=EdFi.Ods.SandboxAdmin"
+                EdFi_Ods      = "Host=localhost; Port=5432; Username=postgres; Database=EdFi_{0}; Pooling=true; Minimum Pool Size=10; Maximum Pool Size=50; Application Name=EdFi.Ods.SandboxAdmin"
+                EdFi_Admin    = "Host=localhost; Port=5432; Username=postgres; Database=EdFi_Admin; Pooling=true; Minimum Pool Size=10; Maximum Pool Size=50; Application Name=EdFi.Ods.SandboxAdmin"
+                EdFi_Security = "Host=localhost; Port=5432; Username=postgres; Database=EdFi_Security; Pooling=true; Minimum Pool Size=10; Maximum Pool Size=50; Application Name=EdFi.Ods.SandboxAdmin"
+                EdFi_Master   = "Host=localhost; Port=5432; Username=postgres; Database=postgres; Pooling=false; Application Name=EdFi.Ods.SandboxAdmin"
             }
         }
     }


### PR DESCRIPTION
When building up a connection configuration Hashtable from a connection string during install, Integrated Security was always being set to true, which later on in the install would cause errors when trying to created a user in Postgres. This differed from the WebApi install where Integrated Security would be false unless it was being set to true as part of a parameter passed in as part of the install, so in the shared function Add-SqlLogins (in AppCommon) it would not try to add the logins and instead warn about not being able to create them and then move onto the next part of the install. Now with this change, Sandbox Admin install will act the same as WebApi when integrated security has not been set.

Additionally while testing this, it would found that the Postgres connection strings were specifying port 5402, while the default port for Postgres is 5432. So this was changed.

The installer change was tested using the package generated from [this build](https://intedfitools1.msdf.org/buildConfiguration/OdsPlatform_OdsImplementationKotlin_Installers_SandboxAdmin/147273)