### PR TITLE
[ODS-5097] Changing the default log location for the Web API running under IIS

### DIFF
--- a/Application/EdFi.Ods.WebApi/Program.cs
+++ b/Application/EdFi.Ods.WebApi/Program.cs
@@ -3,16 +3,12 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Autofac.Extensions.DependencyInjection;
-using EdFi.Ods.Api.Constants;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Log4Net.AspNetCore.Entities;
 
 namespace EdFi.Ods.WebApi
 {
@@ -44,15 +40,6 @@ namespace EdFi.Ods.WebApi
                             ? "log4net.development.config"
                             : "log4net.config"
                     };
-
-                foreach (var propertyOverride in loggingOptions.PropertyOverrides)
-                {
-                    foreach (var attribute in propertyOverride.Attributes.ToList())
-                    {
-                        propertyOverride.Attributes[attribute.Key] = propertyOverride.Attributes[attribute.Key]
-                            .Replace("{version}", ApiVersionConstants.InformationalVersion);
-                    }
-                }
 
                 loggingBuilder.AddLog4Net(loggingOptions);
             }

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -183,9 +183,9 @@ function Install-EdFiOdsWebApi {
         # 
         # Add template string {version} to include API's version.
         # To include a value from an environment variable use ${myVar}
-        # Default: "${LOCALAPPDATA}/WebApiLog.{version}.log".
+        # Default: "${PROGRAMDATA}/Ed-Fi-ODS/WebApiLog.{version}.log".
         [string]
-        $LogDestinationPath = "`${LOCALAPPDATA}/WebApiLog.{version}.log",
+        $LogDestinationPath = "`${PROGRAMDATA}/Ed-Fi-ODS/WebApiLog.{version}.log",
 
         # Web site port number. Default: 443.
         [int]
@@ -290,6 +290,7 @@ function Install-EdFiOdsWebApi {
         DownloadPath = $DownloadPath
         WebSitePath = $WebSitePath
         WebSiteName = $WebsiteName
+        LogDestinationPath = $LogDestinationPath
         WebSitePort = $WebsitePort
         CertThumbprint = $CertThumbprint
         WebApplicationName = $WebApplicationName

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -403,6 +403,19 @@ function Invoke-TransformWebConfigAppSettings {
                     }
                 }
             }
+            # Add a Log4net property override so that logs are stored in ${LOCALAPPDATA}/WebApiLog v{version}.log
+            if($settings.Log4NetCore -eq $Null) { 
+                $settings.Log4NetCore = @{}
+            }
+            if($settings.Log4NetCore.PropertyOverrides -eq $Null) { 
+                $settings.Log4NetCore.PropertyOverrides = @()
+            }
+            $settings.Log4NetCore.PropertyOverrides += @{
+                XPath = "/log4net/appender[@name='RollingFile']/file"
+                Attributes = @{
+                    Value = "`${LOCALAPPDATA}/WebApiLog v{version}.log"
+                }
+            }
            $settings.BearerTokenTimeoutMinutes=$Config.WebApiFeatures.BearerTokenTimeoutMinutes
            $settings.ApiSettings.ExcludedExtensions=$Config.WebApiFeatures.ExcludedExtensions
            New-JsonFile $settingsFile $settings -Overwrite

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -181,7 +181,7 @@ function Install-EdFiOdsWebApi {
 
         # Log destination path. 
         # 
-        # Add template string {version} to include API's version.
+        # Use {version} template string to include API's version.
         # To include a value from an environment variable use ${myVar}
         # Default: "${PROGRAMDATA}/Ed-Fi-ODS/WebApiLog.{version}.log".
         [string]
@@ -419,16 +419,19 @@ function Invoke-TransformWebConfigAppSettings {
                 throw "Invalid PackageVersion provided $($Config.PackageVersion). PackageVersion must include major and minor."
             }
             $logDestination = $Config.LogDestinationPath.replace("{version}", -join($splitPackageVersion[0], ".", $splitPackageVersion[1]))
-            if($settings.Log4NetCore -eq $Null) { 
+            if($Null -eq $settings.Log4NetCore) { 
                 $settings.Log4NetCore = @{}
             }
-            if($settings.Log4NetCore.PropertyOverrides -eq $Null) { 
+            if($Null -eq $settings.Log4NetCore.PropertyOverrides) { 
                 $settings.Log4NetCore.PropertyOverrides = @()
             }
-            $settings.Log4NetCore.PropertyOverrides += @{
-                XPath = "/log4net/appender[@name='RollingFile']/file"
-                Attributes = @{
-                    Value = $logDestination
+            $rollingFileXpath = "/log4net/appender[@name='RollingFile']/file"
+            if($settings.Log4NetCore.PropertyOverrides.Where({$_.XPath -eq $rollingFileXpath}).Count -eq 0) {
+                $settings.Log4NetCore.PropertyOverrides += @{
+                    XPath = $rollingFileXpath
+                    Attributes = @{
+                        Value = $logDestination
+                    }
                 }
             }
            $settings.BearerTokenTimeoutMinutes=$Config.WebApiFeatures.BearerTokenTimeoutMinutes


### PR DESCRIPTION
Note for the reviewer, I've removed log "Loading configuration files" since it doesn't seem to add value; if you consider it necessary, I can bring it back right after Log4net is initialized.