### PR TITLE
ODS-5241 - Update to use latest CodeGen for NET6

### DIFF
--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
@@ -31,8 +31,8 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
@@ -52,6 +52,7 @@
     <ProjectReference Include="..\..\..\Ed-Fi-ODS\Application\EdFi.Ods.Features\EdFi.Ods.Features.csproj" />
     <ProjectReference Include="..\..\..\Ed-Fi-ODS\Application\EdFi.Ods.Profiles.Test\EdFi.Ods.Profiles.Test.csproj" />
     <ProjectReference Include="..\..\..\Ed-Fi-ODS\Application\EdFi.Ods.Standard\EdFi.Ods.Standard.csproj" />
+    <ProjectReference Include="..\..\..\Ed-Fi-ODS-Implementation\Application\EdFi.Ods.Features.OwnershipBasedAuthorization\EdFi.Ods.Features.OwnershipBasedAuthorization.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/appsettings.json
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/appsettings.json
@@ -51,7 +51,7 @@
       },
       {
         "Name": "OwnershipBasedAuthorization",
-        "IsEnabled": false
+        "IsEnabled": true
       },
       {
         "Name": "UniqueIdValidation",

--- a/Application/EdFi.Ods.Features.OwnershipBasedAuthorization/EdFi.Ods.Features.OwnershipBasedAuthorization.csproj
+++ b/Application/EdFi.Ods.Features.OwnershipBasedAuthorization/EdFi.Ods.Features.OwnershipBasedAuthorization.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
+++ b/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.3.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.2" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Hangfire" Version="1.7.17" />

--- a/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
+++ b/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.3.43" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.3.43" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
@@ -44,6 +44,7 @@
     <ProjectReference Include="..\..\..\Ed-Fi-ODS\Application\EdFi.Ods.Composites.Enrollment\EdFi.Ods.Composites.Enrollment.csproj" />
     <ProjectReference Include="..\..\..\Ed-Fi-ODS\Application\EdFi.Ods.Features\EdFi.Ods.Features.csproj" />
     <ProjectReference Include="..\..\..\Ed-Fi-ODS\Application\EdFi.Ods.Standard\EdFi.Ods.Standard.csproj" />
+    <ProjectReference Include="..\..\..\Ed-Fi-ODS-Implementation\Application\EdFi.Ods.Features.OwnershipBasedAuthorization\EdFi.Ods.Features.OwnershipBasedAuthorization.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "5.3.777",
+      "PackageVersion": "5.4.28",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -2,62 +2,62 @@
   "packages": {
     "EdFiMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template",
-      "PackageVersion": "5.3.253",
+      "PackageVersion": "5.4.4",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "GrandBend": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template",
-      "PackageVersion": "5.3.297",
+      "PackageVersion": "5.4.7",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL",
-      "PackageVersion": "5.3.232",
+      "PackageVersion": "5.4.4",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlPopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.PostgreSQL",
-      "PackageVersion": "5.3.247",
+      "PackageVersion": "5.4.4",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCoreMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core",
-      "PackageVersion": "5.3.87",
+      "PackageVersion": "5.4.4",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core",
-      "PackageVersion": "5.3.246",
+      "PackageVersion": "5.4.5",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.PostgreSQL",
-      "PackageVersion": "5.3.77",
+      "PackageVersion": "5.4.4",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlPopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.PostgreSQL",
-      "PackageVersion": "5.3.224",
+      "PackageVersion": "5.4.4",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "homograph": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Homograph",
-      "PackageVersion": "5.3.15",
+      "PackageVersion": "5.4.3",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "profiles.sample": {
       "PackageName": "EdFi.Suite3.Ods.Profiles.Sample",
-      "PackageVersion": "5.3.3",
+      "PackageVersion": "5.4.3",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "sample": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Sample",
-      "PackageVersion": "5.3.14",
+      "PackageVersion": "5.4.3",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "tpdm": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.TPDM.Core.1.1.0",
-      "PackageVersion": "5.3.38",
+      "PackageVersion": "5.4.3",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Ods.CodeGen": {

--- a/logistics/scripts/modules/postmanTestHarnessConfiguration.json
+++ b/logistics/scripts/modules/postmanTestHarnessConfiguration.json
@@ -870,12 +870,33 @@
           "ApiClients": [
             {
               "ApiClientName": "MultipleEdorg_255901999_5001_51",
-              "LocalEducationOrganizations": [255901999, 51, 5001]
+              "LocalEducationOrganizations": [ 255901999, 51, 5001 ]
             }
           ]
         }
       ],
-      "NamespacePrefixes": ["uri://ed-fi.org"]
+      "NamespacePrefixes": [ "uri://ed-fi.org" ]
+    },
+    {
+      "Email": "RecordOwnership@ed-fi.org",
+      "VendorName": "Record Ownership",
+      "Applications": [
+        {
+          "ApplicationName": "ODS/API",
+          "ClaimSetName": "Ed-Fi Sandbox",
+          "ApiClients": [
+            {
+              "ApiClientName": "255901-A",
+              "LocalEducationOrganizations": [ 255901 ]
+            },
+            {
+              "ApiClientName": "255901-B",
+              "LocalEducationOrganizations": [ 255901 ]
+            }
+          ]
+        }
+      ],
+      "NamespacePrefixes": [ "uri://ed-fi.org" ]
     }
   ]
 }


### PR DESCRIPTION
This brought in latest from main and updated configuration.packages.json to reference the latest codegen built on net6.

Please note that tests will still be failing as part of this and are covered in ODS-5242. For this you should see CodeGen version 5.4.28 able to be installed and run and that the solution will build.