### PR TITLE
ODS-5242 - Fix Invoke-DotnetTest

### DIFF
--- a/logistics/scripts/run-tests.ps1
+++ b/logistics/scripts/run-tests.ps1
@@ -5,7 +5,7 @@
 
 & "$PSScriptRoot\modules\load-path-resolver.ps1"
 
-$testAssemblies = (Get-ChildItem -recurse -File $((Get-RepositoryRoot "ed-fi-ods") + "\*Tests.dll") | Where-Object { $_.FullName -match "\\bin\\?" -and $_.FullName -notmatch "\\net48\\?" -and $_.fullName -notmatch "ApprovalTests.dll" })
+$testAssemblies = (Get-ChildItem -recurse -File $((Get-RepositoryRoot "ed-fi-ods") + "\*Tests.dll") | Where-Object { $_.FullName -match "\\bin\\?" -and $_.FullName -notmatch "\\net48\\?" -and $_.fullName -notmatch "ApprovalTests.dll" -and $_.fullName -notmatch "\\ref\\?" })
 $reports = (Get-RepositoryRoot "ed-fi-ods-implementation") + "\reports\"
 
 if (Test-Path $reports) {


### PR DESCRIPTION
This fixes an issue found where when invoking dotnet test there were errors since with anything past NET5, a reference assembly is put in a ref folder, and then dotnet test was trying to execute against those items, as seen in the screenshot below. This was resolved by filtering out the ref folder.

Please not that other tests will still be failing on this build and will be handled by later tickets.

On feature-net6 branch currently:
![image](https://user-images.githubusercontent.com/1013553/151875249-3fc3ec9d-b310-4531-8953-39aa24ffb024.png)

On this branch now:
![image](https://user-images.githubusercontent.com/1013553/151875577-fbb0d1ce-154d-40dd-b0b7-0c591daebddc.png)
