### PR TITLE
[ODS-5269] Upgrade Glendale and Northridge to v5.3

### DIFF
--- a/DatabaseTemplate/Scripts/Glendale.ps1
+++ b/DatabaseTemplate/Scripts/Glendale.ps1
@@ -4,8 +4,8 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 $params = @{
-    sourceUrl = "https://odsassets.blob.core.windows.net/public/Glendale/EdFi_Ods_Glendale_v51_20210114.7z"
-    fileName  = "EdFi_Ods_Glendale_v510.bak"
+    sourceUrl = "https://odsassets.blob.core.windows.net/public/Glendale/EdFi_Ods_Glendale_v53_20220120.7z"
+    fileName  = "EdFi_Ods_Glendale_v53_20220120.7z"
 }
 
 return (& "$PSScriptRoot\..\Modules\get-template-from-web.ps1" @params)

--- a/DatabaseTemplate/Scripts/Northridge.ps1
+++ b/DatabaseTemplate/Scripts/Northridge.ps1
@@ -4,8 +4,8 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 $params = @{
-    sourceUrl = "https://odsassets.blob.core.windows.net/public/Northridge/EdFi_Ods_Northridge_v51_20210224.7z"
-    fileName  = "EdFi_Ods_Northridge_v510.bak"
+    sourceUrl = "https://odsassets.blob.core.windows.net/public/Northridge/EdFi_Ods_Northridge_v53_20220120.7z"
+    fileName  = "EdFi_Ods_Northridge_v53_20220120.7z"
 }
 
 return (& "$PSScriptRoot\..\Modules\get-template-from-web.ps1" @params)


### PR DESCRIPTION
Test with v5.3 or with removal of 1330-UpdateVersionTo54.sql to avoid running into upgrade scenario. 