### PR TITLE
ODS-5246 - Update path access for SDK Gen Console

### DIFF
--- a/logistics/scripts/modules/TestHarness.psm1
+++ b/logistics/scripts/modules/TestHarness.psm1
@@ -61,6 +61,16 @@ function Get-TestHarnessExecutable {
     return $testHarnessExecutable
 }
 
+function Get-SdkGenExecutable {
+    Param(
+        [string] $buildConfiguration = "Debug"
+    )
+    $sdkGenExecutableFilter = "$(Get-RepositoryResolvedPath "\Utilities\SdkGen\EdFi.SdkGen.Console\bin\$buildConfiguration\**\EdFi.SdkGen.Console.exe")"
+    $sdkGenExecutable = (Get-ChildItem -Recurse -Path $sdkGenExecutableFilter).FullName
+
+    return $sdkGenExecutable
+}
+
 function Invoke-SdkGenConsole {
     Param(
         [Parameter(Mandatory = $true)] [string] $apiMetadataUrl,
@@ -68,8 +78,7 @@ function Invoke-SdkGenConsole {
     )
     
     $sdkGenConsoleFolder = (Get-RepositoryResolvedPath "/Utilities/SdkGen/EdFi.SdkGen.Console")
-    $sdkGenConsoleExecutableFolder = Join-Path -Path $sdkGenConsoleFolder -ChildPath "/bin/$buildConfiguration/netcoreapp3.1"
-    $sdkGenConsoleExecutableFolderFullPath = (Join-Path $sdkGenConsoleExecutableFolder 'EdFi.SdkGen.Console.exe')
+    $sdkGenConsoleExecutableFolderFullPath = (Get-SdkGenExecutable $buildConfiguration)
     Start-Process $sdkGenConsoleExecutableFolderFullPath -ArgumentList @('-m', $apiMetadataUrl, '-p', '-c', '-i') -WorkingDirectory $sdkGenConsoleFolder -NoNewWindow -Wait | Out-Host
 }
 


### PR DESCRIPTION
Previously it was hard coded to pull netcoreapp31 and now instead it will use a wildcard like what is used for finding the TestHarness executable.