### PR TITLE
[ODS-5287] Sandbox Admin throws an exception during startup

### DIFF
--- a/Application/EdFi.Ods.SandboxAdmin/Contexts/PostgresIdentityContext.cs
+++ b/Application/EdFi.Ods.SandboxAdmin/Contexts/PostgresIdentityContext.cs
@@ -5,6 +5,7 @@
 
 using EdFi.Admin.DataAccess.Providers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace EdFi.Ods.Sandbox.Admin.Contexts
 {
@@ -23,11 +24,13 @@ namespace EdFi.Ods.Sandbox.Admin.Contexts
             modelBuilder.HasDefaultSchema("dbo");
             foreach (var entity in modelBuilder.Model.GetEntityTypes())
             {
-                entity.SetTableName(entity.GetTableName().ToLower());
+                var tableId = StoreObjectIdentifier.Table(entity.GetTableName().ToLower(), entity.GetSchema());
+
+                entity.SetTableName(tableId.Name);
 
                 foreach (var property in entity.GetProperties())
                 {
-                    property.SetColumnName(property.GetColumnName().ToLower());
+                    property.SetColumnName(property.GetColumnName(tableId).ToLower());
                 }
 
                 foreach (var key in entity.GetKeys())
@@ -42,7 +45,7 @@ namespace EdFi.Ods.Sandbox.Admin.Contexts
 
                 foreach (var index in entity.GetIndexes())
                 {
-                    index.SetName(index.GetName().ToLower());
+                    index.SetDatabaseName(index.GetDatabaseName().ToLower());
                 }
             }
         }

--- a/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
+++ b/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.1.1" />
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1" />
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.2" />
@@ -20,18 +20,18 @@
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.2" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
-    <PackageReference Include="Hangfire" Version="1.7.17" />
-    <PackageReference Include="Hangfire.PostgreSql" Version="1.8.0" />
-    <PackageReference Include="log4net" Version="2.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.10" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
+    <PackageReference Include="Hangfire" Version="1.7.28" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.9.5" />
+    <PackageReference Include="log4net" Version="2.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
-    <PackageReference Include="NHibernate" Version="5.2.7" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
+    <PackageReference Include="NHibernate" Version="5.3.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.SandboxAdmin/Startup.cs
+++ b/Application/EdFi.Ods.SandboxAdmin/Startup.cs
@@ -245,7 +245,6 @@ namespace EdFi.Ods.SandboxAdmin
 
             app.UseAuthorization();
 
-            app.UseHangfireServer();
             var backgroundJob = Container.Resolve<IBackgroundJobService>();
             backgroundJob.Configure();
 


### PR DESCRIPTION
[UseHangfireServer got deprecated in favor of AddHangfireServer](https://www.hangfire.io/blog/2021/08/30/hangfire-1.7.25.html), however, there is already a call to _AddHangfireServer_ so the call to _UseHangfireServer_ can be safely removed.