### PR TITLE
[ODS-5247] Update Npgsql and HealthChecks libraries

### DIFF
--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
@@ -31,8 +31,8 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.19" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.9" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />

--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
   </ItemGroup>

--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/Program.cs
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/Program.cs
@@ -34,6 +34,8 @@ namespace EdFi.Ods.Api.IntegrationTestHarness
                 .UseServiceProviderFactory(new AutofacServiceProviderFactory())
                 .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); }).Build();
 
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+            
             await host.RunAsync();
 
             static void ConfigureLogging()

--- a/Application/EdFi.Ods.Features.OwnershipBasedAuthorization/EdFi.Ods.Features.OwnershipBasedAuthorization.csproj
+++ b/Application/EdFi.Ods.Features.OwnershipBasedAuthorization/EdFi.Ods.Features.OwnershipBasedAuthorization.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
     <PackageReference Include="Iesi.Collections" Version="4.0.4" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
+++ b/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1" />
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.19" />
-    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.10" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.9" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
+    <PackageReference Include="EdFi.Suite3.Common" Version="5.4.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Hangfire" Version="1.7.28" />

--- a/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
+++ b/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NHibernate" Version="5.2.7" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
-    <PackageReference Include="Npgsql" Version="4.1.5" />
+    <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
+++ b/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.19" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.9" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="5.4.20" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="5.4.10" />
     <PackageReference Include="FluentValidation" Version="8.6.3" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />


### PR DESCRIPTION
Cannot write DateTime with Kind=UTC to PostgreSQL type 'timestamp without time zone', consider using 'timestamp with time zone'. Note that it's not possible to mix DateTimes with different Kinds in an array/range. See the Npgsql.EnableLegacyTimestampBehavior AppContext switch to enable legacy behavior.

I was getting above error after upgrading to Npgsql package to "6.0.3"  .Basically posgreSQl default to timestamp with time zone  now So I added additional code to make it work like before with  AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
And then it will use timestamp without time zone for ClientAccessToken class - Expiration property for example here
Reference Links
https://stackoverflow.com/questions/70643895/how-to-say-datetime-timestamp-without-time-zone-in-ef-core-6-0
https://github.com/npgsql/doc/blob/main/conceptual/Npgsql/types/datetime.md/
https://github.com/npgsql/efcore.pg/issues/2000

Note
One of the builds here is currently failing due to a previous merge causing builds to fail on main. Once that is addressed this PR will be updated.