### PR TITLE
ODS-5075 - Swap order of scripts paths passed for DbDeploy execution

### DIFF
--- a/logistics/scripts/modules/config/config-management.psm1
+++ b/logistics/scripts/modules/config/config-management.psm1
@@ -43,8 +43,8 @@ function Get-DefaultSubtypes {
 function Get-RepositoryArtifactPaths {
     $filePaths = @()
 
-    Get-RepositoryNames | ForEach-Object { $filePaths += (Get-RepositoryRoot $_) }
     $filePaths += (Get-RepositoryResolvedPath("Application\EdFi.Ods.Standard")).Path
+    Get-RepositoryNames | ForEach-Object { $filePaths += (Get-RepositoryRoot $_) }
 
     return $filePaths
 }


### PR DESCRIPTION
In the powershell script we pull the paths database scripts might be contained in, and the order the paths were pulled in the script is how they would be passed to DbDeploy, and it was ordered as follows before:
Ed-Fi-ODS
Ed-Fi-ODS-Implementation
Ed-Fi-ODS\Application\EdFi.Ods.Standard
Ed-Fi-ODS-Implementation\Plugin

With Implementation being ordered before Standard, if Implementation had scripts in it, such as putting a script in `Ed-Fi-ODS-Implementation\Artifacts\MsSql\Structure\Ods`, then when DbDeploy ran that got executed first and logged in the DeployJournal, and then when Standard scripts were looked at, [this line](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-Databases/blob/main/src/EdFi.Db.Deploy/DatabaseCommands/DeployDatabaseFromPathCommand.cs#L118) in DbDeploy would be evaluated and return true since they are structure scripts, it is ODS, it is the standards script path, there is an upgrade (since there are scripts present), and there were already executed scripts. So then the result would be returned with the exception to say the upgrade is not supported.

The change done here was to put the Standard folder first in the paths collected, this way when its passed to DbDeploy, that is the first one to run, and it will establish the database, and then when the Implementation folder scripts get looked at and that same if statement evaluates, it would evaluate false since they are structure scripts, it is ODS, it is an upgrade, there are already executed scripts, BUT it is not the structure scripts folder. So then the upgrade would proceed as it should.