### PR TITLE
ODS-5184 WebApi Postgres install does not include port number in connection string in appsettings

### DIFF
--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -147,7 +147,7 @@
     },
     "AppCommon": {
       "PackageName": "EdFi.Installer.AppCommon",
-      "PackageVersion": "2.0.0-pre0007",
+      "PackageVersion": "2.0.0-pre0009",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Ods.Common": {


### PR DESCRIPTION
Note
One of the builds here is currently failing due to a previous merge causing builds to fail on main. Once that is addressed this PR will be updated.