### PR TITLE
[ODS-5112] - Make WebApplicationPath and WebSitePath function as separate parameters

### DIFF
--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
@@ -45,9 +45,9 @@ function Install-EdFiOdsSandboxAdmin {
     .EXAMPLE
         PS c:\> $parameters = @{
             PackageVersion     = '5.1.0'
-            WebSitePath        = 'c:\inetpub\SandboxAdmin'
+            WebSitePath        = 'c:\inetpub\Ed-Fi'
             WebSitePort        = 8765
-            WebApplicationPath = 'c:\inetpub\SandboxAdmin\5.1.0'
+            WebApplicationPath = 'SandboxAdmin'
             WebApplicationName = 'SandboxAdmin5.1.0'
             Settings           = @{
                 ConnectionStrings            = @{
@@ -121,9 +121,9 @@ function Install-EdFiOdsSandboxAdmin {
         [int]
         $WebSitePort = 443,
 
-        # Path for the web application. Default: "c:\inetpub\Ed-Fi\SandboxAdmin".
+        # Path for the web application. Default: "SandboxAdmin".
         [string]
-        $WebApplicationPath = "c:\inetpub\Ed-Fi\SandboxAdmin", # NB: _must_ use backslash with IIS settings
+        $WebApplicationPath = "SandboxAdmin", # NB: _must_ use backslash with IIS settings
 
         # Web application name. Default: "SandboxAdmin".
         [string]
@@ -146,7 +146,7 @@ function Install-EdFiOdsSandboxAdmin {
     $result = @()
 
     $config = @{
-        WebApplicationPath = $WebApplicationPath
+        WebApplicationPath = (Join-Path $WebSitePath $WebApplicationPath)
         PackageName        = $PackageName
         PackageVersion     = $PackageVersion
         PackageSource      = $PackageSource

--- a/Scripts/NuGet/EdFi.Installer.SwaggerUI/Install-EdFiOdsSwaggerUI.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SwaggerUI/Install-EdFiOdsSwaggerUI.psm1
@@ -38,7 +38,7 @@ function Install-EdFiOdsSwaggerUI {
             ToolsPath = "C:/temp/tools"
             WebApiMetadataUrl = "https://my-server.example/EdFiOdsWebApi/metadata"
             WebApiVersionUrl = "https://my-server.example/EdFiOdsWebApi"
-            WebSitePath="c:\inetpub\Ed-Fi-3"
+            WebSitePath="c:\inetpub\Ed-Fi"
             WebApplicationPath="SwaggerUI"
         }
         PS c:\> Install-EdFiOdsSwaggerUI @parameters

--- a/Scripts/NuGet/EdFi.Installer.SwaggerUI/Install-EdFiOdsSwaggerUI.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SwaggerUI/Install-EdFiOdsSwaggerUI.psm1
@@ -38,6 +38,8 @@ function Install-EdFiOdsSwaggerUI {
             ToolsPath = "C:/temp/tools"
             WebApiMetadataUrl = "https://my-server.example/EdFiOdsWebApi/metadata"
             WebApiVersionUrl = "https://my-server.example/EdFiOdsWebApi"
+            WebSitePath="c:\inetpub\Ed-Fi-3"
+            WebApplicationPath="SwaggerUI"
         }
         PS c:\> Install-EdFiOdsSwaggerUI @parameters
     #>
@@ -75,9 +77,9 @@ function Install-EdFiOdsSwaggerUI {
         [int]
         $WebSitePort = 443,
 
-        # Path for the web application. Default: "c:\inetpub\Ed-Fi\SwaggerUI".
+        # Path for the web application. Default: "SwaggerUI".
         [string]
-        $WebApplicationPath = "c:\inetpub\Ed-Fi\SwaggerUI", # NB: _must_ use backslash with IIS settings
+        $WebApplicationPath = "SwaggerUI", # NB: _must_ use backslash with IIS settings
 
         # Web application name. Default: "SwaggerUI".
         [string]
@@ -117,7 +119,7 @@ function Install-EdFiOdsSwaggerUI {
     $result = @()
 
     $Config = @{
-        WebApplicationPath = $WebApplicationPath
+        WebApplicationPath = (Join-Path $WebSitePath $WebApplicationPath)
         PackageName = $PackageName
         PackageVersion = $PackageVersion
         PackageSource = $PackageSource

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -88,8 +88,8 @@ function Install-EdFiOdsWebApi {
                 Username="ods-admin"
             }
             WebSiteName="Ed-Fi-3"
-            WebSitePath="c:\inetpub\Ed-Fi-3"
-            WebApplicationPath="EdFiOdsApi-3"
+            WebSitePath="c:\inetpub\Ed-Fi"
+            WebApplicationPath="EdFiOdsApi"
             WebSitePort=843
             CertThumbprint="a909502dd82ae41433e6f83886b00d4277a32a7b"
         }

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -89,7 +89,7 @@ function Install-EdFiOdsWebApi {
             }
             WebSiteName="Ed-Fi-3"
             WebSitePath="c:\inetpub\Ed-Fi-3"
-            WebApplicationPath="d:/octopus/applications/staging/EdFiOdsApi-3"
+            WebApplicationPath="EdFiOdsApi-3"
             WebSitePort=843
             CertThumbprint="a909502dd82ae41433e6f83886b00d4277a32a7b"
         }
@@ -191,9 +191,9 @@ function Install-EdFiOdsWebApi {
         [int]
         $WebSitePort = 443,
 
-        # Path for the web application. Default: "c:\inetpub\Ed-Fi\WebApi".
+        # Directory for the web application. Default: "WebApi".
         [string]
-        $WebApplicationPath = "c:\inetpub\Ed-Fi\WebApi", # NB: _must_ use backslash with IIS settings
+        $WebApplicationPath = "WebApi", # NB: _must_ use backslash with IIS settings
 
         # Web application name. Default: "WebApi".
         [string]
@@ -282,7 +282,7 @@ function Install-EdFiOdsWebApi {
     $result = @()
 
     $config = @{
-        WebApplicationPath = $WebApplicationPath
+        WebApplicationPath = (Join-Path $WebSitePath $WebApplicationPath)
         PackageName = $PackageName
         PackageVersion = $PackageVersion
         PackageSource = $PackageSource


### PR DESCRIPTION
Before this change, you could specify values for both of the parameters, but SwaggerUI and the API would only get installed to wherever was specified in the WebApplicationPath parameter. Now the installers have been changed so that WebSitePath signifies the base path to the Ed-Fi Website setup in IIS, and then WebApplicationPath will be the subfolder for where each specific application is installed under the Ed-Fi Website. This matches the changes that were done as part of the AdminApp installer as well.

To test this:

1. Make sure you don't already have any EdFi sites setup in IIS.
2. Download the updated installer for WebApi, version 6.0.2 [here](https://dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_artifacts/feed/EdFi/NuGet/EdFi.Suite3.Installer.WebApi/6.0.2/overview)
3. Follow the [getting started directions](https://techdocs.ed-fi.org/display/ODSAPIS3V54/Sandbox+Installation+Steps) by running the database installer if you do not have databases setup for testing this.
4. Extract the newly downloaded WebApi installer, import the module, and specifying parameters for the install, making sure to specify custom values for WebSitePath and WebApplicationPath such as:
5. `$parameters = @{ PackageVersion = "5.3.1434"; DbConnectionInfo = @{ Engine="SqlServer"; Server="localhost"; UseIntegratedSecurity=$true }; InstallType = "Sandbox"; WebSitePath = "C:\inetpub\EdFiTesting"; WebApplicationPath = "WebApi54" }`
6. Install the API with those parameters like so: `Install-EdFiOdsWebApi @parameters`
7. Once the install has complete, go to combined path of where you said to install the WebApi and confirm the contents are there
8. Open IIS and confirm you see an Ed-Fi site, and inside it see a WebApi site as well. If the WebApplicationPath is something besides WebApi you will notice that IIS shows a folder with the custom folder name as well. It shows this way since the folder is a different name from the Application name,  and is under the Ed-Fi site folder. You cannot publicly browse the folder though so it is not accessible in any way besides as the WebApi site. A screenshot at the bottom of this description shows what I mean.
9. Download the updated installer for Swagger UI, version 6.0.2 [here](https://dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_artifacts/feed/EdFi/NuGet/EdFi.Suite3.Installer.SwaggerUI/6.0.2/overview)
10. Follow the getting started directions and specify parameters for the install like so, making sure to input custom values for WebSitePath and WebApplicationPath like you did for the WebApi, such as:
11. `$parameters = @{ PackageVersion = "5.3.1146"; WebApiVersionUrl = "https://localhost/WebApi"; WebSitePath = "C:\inetpub\EdFiTesting"; WebApplicationPath = "Swagger\Goes\Here" }`
12. Install SwaggerUI with those parameters like so: `Install-EdFiOdsSwaggerUI @parameters`
13. Once the install is complete, confirm that Swagger was installed to the combined path specified
14. Open IIS and confirm you see SwaggerUI under the Ed-Fi site, and that it is mapped to the folder you specified for install and that it loads
15. Just like WebApi, you will see a folder under the Ed-Fi site that shows up for the same reasons, but it cannot be publicly browsed.
16. Download the updated installer for Sandbox Admin, version 6.0.3 [here](https://dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_artifacts/feed/EdFi/NuGet/EdFi.Suite3.Installer.SandboxAdmin/6.0.3/overview)
17. Following the getting started directions and specify parameters for the install like so, making sure to input custom values for WebSitePath and WebApplicationPath like you did for WebApi and Swagger, such as:
18. `$parameters = @{ PackageVersion = "5.3.1146" ; OAuthUrl = "https://YOUR_SITE_OR_SERVER_NAME_HERE/WebApi"; WebSitePath = "C:\inetput\EdFiTesting"; WebApplicationPath = "SandboxAdmin\Path\Here" }`
19. Install Sandbox Admin with those parameters like so: `Install-EdFiOdsSandboxAdmin @parameters`
20. Once the install is complete, confirm that Sandbox Admin was installed to the combined path specified
21. Open IIS and confirm you see SandboxAdmin under the Ed-Fi site and that it is mapped to the folder you specified for install and that it loads
22. Remove all sites in IIS
23. Repeat the same steps above, but in the parameters remove the custom values for WebSitePath and WebApplication path and confirm that with both installers they installed to the default locations, they show up in IIS as they should, and they load like they should.


![image](https://user-images.githubusercontent.com/1013553/166290707-4e0883ca-021f-48e1-9667-c8b3b6591a21.png)
