### PR TITLE
[ODS-5363] Create a PowerShell function that returns whether it's running on Windows

### DIFF
--- a/logistics/scripts/modules/database/postgres-database-management.psm1
+++ b/logistics/scripts/modules/database/postgres-database-management.psm1
@@ -24,10 +24,6 @@ function Test-PostgreSQLBinariesInstalled {
             return $true
         }
         catch {
-            Write-Host "ERROR:  Postgres client binaries are not installed on this Unix-like system." -ForegroundColor Red
-            Write-Host "To install them you can run:" -ForegroundColor Red
-            Write-Host "    Ubuntu: apt-get install postgresql-client" -ForegroundColor Red
-            Write-Host "    Alpine: apk add postgresql-client" -ForegroundColor Red
             return $false
         }
     }
@@ -67,7 +63,14 @@ function Install-PostgreSQLBinaries {
     $packagePath = Get-NuGetPackage @parameters
 
     if (-not (Test-PostgreSQLBinariesInstalled)) {
-        throw "Could not find PostgreSQL binaries in $script:toolsPath\$script:packageName\tools. "
+        if(Get-IsWindows){
+            throw "Could not find PostgreSQL binaries in $script:toolsPath\$script:packageName\tools. "
+        }else{
+            throw "ERROR:  Postgres client binaries are not installed on this Unix-like system.
+                    To install them you can run:
+                        Ubuntu: apt-get install postgresql-client
+                        Alpine: apk add postgresql-client"
+        }
     }
 }
 

--- a/logistics/scripts/modules/database/postgres-database-management.psm1
+++ b/logistics/scripts/modules/database/postgres-database-management.psm1
@@ -7,6 +7,7 @@ $ErrorActionPreference = "Stop"
 
 & "$PSScriptRoot\..\..\..\..\logistics\scripts\modules\load-path-resolver.ps1"
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\tasks\TaskHelper.psm1")
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\utility\cross-platform.psm1")
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\tools\ToolsHelper.psm1")
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\packaging\nuget-helper.psm1')
 
@@ -17,6 +18,20 @@ $script:packageName = "PostgreSQL.Binaries"
 $script:packageVersion = "12.2.0"
 
 function Test-PostgreSQLBinariesInstalled {
+    if (!(Get-IsWindows)) {
+        try {
+            psql -V
+        }
+        catch {
+            Write-Host "ERROR:  Postgres client binaries are not installed on this Unix system." -ForegroundColor Red
+            Write-Host "To install them you can run:" -ForegroundColor Red
+            Write-Host "    Ubuntu: apt-get install postgresql-client" -ForegroundColor Red
+            Write-Host "    Alpine: apk add postgresql-client" -ForegroundColor Red
+            return
+        }
+    }
+
+
     $packagePath = "$script:toolsPath/$script:packageName.$script:packageVersion"
 
     $psqlExists = (Test-Path "$packagePath/tools/psql.exe")

--- a/logistics/scripts/modules/database/postgres-database-management.psm1
+++ b/logistics/scripts/modules/database/postgres-database-management.psm1
@@ -27,7 +27,7 @@ function Test-PostgreSQLBinariesInstalled {
             Write-Host "To install them you can run:" -ForegroundColor Red
             Write-Host "    Ubuntu: apt-get install postgresql-client" -ForegroundColor Red
             Write-Host "    Alpine: apk add postgresql-client" -ForegroundColor Red
-            return
+            return $false
         }
     }
 

--- a/logistics/scripts/modules/database/postgres-database-management.psm1
+++ b/logistics/scripts/modules/database/postgres-database-management.psm1
@@ -20,17 +20,17 @@ $script:packageVersion = "12.2.0"
 function Test-PostgreSQLBinariesInstalled {
     if (!(Get-IsWindows)) {
         try {
-            psql -V
+            (psql -V | Out-Null)
+            return $true
         }
         catch {
-            Write-Host "ERROR:  Postgres client binaries are not installed on this Unix system." -ForegroundColor Red
+            Write-Host "ERROR:  Postgres client binaries are not installed on this Unix-like system." -ForegroundColor Red
             Write-Host "To install them you can run:" -ForegroundColor Red
             Write-Host "    Ubuntu: apt-get install postgresql-client" -ForegroundColor Red
             Write-Host "    Alpine: apk add postgresql-client" -ForegroundColor Red
             return $false
         }
     }
-
 
     $packagePath = "$script:toolsPath/$script:packageName.$script:packageVersion"
 

--- a/logistics/scripts/modules/packaging/nuget-helper.psm1
+++ b/logistics/scripts/modules/packaging/nuget-helper.psm1
@@ -33,8 +33,7 @@ function Install-NuGetCli {
             mono -V
         }
         catch {
-            Write-Host "ERROR:  Mono is not installed on this Unix system." -ForegroundColor Red
-            return
+            throw "ERROR:  Mono is not installed on this Unix-like system."
         }
     }
 

--- a/logistics/scripts/modules/packaging/nuget-helper.psm1
+++ b/logistics/scripts/modules/packaging/nuget-helper.psm1
@@ -3,6 +3,9 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
+& "$PSScriptRoot\..\..\..\..\logistics\scripts\modules\load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\utility\cross-platform.psm1")
+
 function Install-NuGetCli {
     <#
     .SYNOPSIS
@@ -24,6 +27,16 @@ function Install-NuGetCli {
 
         [string] $sourceNuGetExe = "https://dist.nuget.org/win-x86-commandline/v5.3.1/nuget.exe"
     )
+
+    if (!(Get-IsWindows)) {
+        try {
+            mono -V
+        }
+        catch {
+            Write-Host "ERROR:  Mono is not installed on this Unix system." -ForegroundColor Red
+            return
+        }
+    }
 
     if (-not $(Test-Path $ToolsPath)) {
         mkdir $ToolsPath | Out-Null

--- a/logistics/scripts/modules/packaging/nuget-helper.psm1
+++ b/logistics/scripts/modules/packaging/nuget-helper.psm1
@@ -30,7 +30,7 @@ function Install-NuGetCli {
 
     if (!(Get-IsWindows)) {
         try {
-            mono -V
+            ( mono -V  | Out-Null )
         }
         catch {
             throw "ERROR:  Mono is not installed on this Unix-like system."

--- a/logistics/scripts/modules/utility/cross-platform.psm1
+++ b/logistics/scripts/modules/utility/cross-platform.psm1
@@ -1,0 +1,15 @@
+function GetIsWindows {
+    <#
+    .SYNOPSIS
+        Checks to see if the current machine is a Windows machine.
+    
+    .EXAMPLE
+        GetIsWindows
+
+        returns $True
+    #>
+
+
+}
+
+Export-ModuleMember -Function "GetIsWindows"

--- a/logistics/scripts/modules/utility/cross-platform.psm1
+++ b/logistics/scripts/modules/utility/cross-platform.psm1
@@ -10,6 +10,9 @@ function Get-IsWindows {
     #>
 
     if ($null -eq $IsWindows) {
+        # This section will only trigger when the automatic $IsWindows variable is not detected.
+        # Every version of PS released on Linux contains this variable so it will always exist.
+        # $IsWindows does not exist pre PS 6, so this will create it in that case.
         $IsWindows = $true
     }
 

--- a/logistics/scripts/modules/utility/cross-platform.psm1
+++ b/logistics/scripts/modules/utility/cross-platform.psm1
@@ -10,7 +10,6 @@ function Get-IsWindows {
     #>
 
     if (!$IsWindows) {
-        $IsUnix = $false
         $IsWindows = $true
     }
 

--- a/logistics/scripts/modules/utility/cross-platform.psm1
+++ b/logistics/scripts/modules/utility/cross-platform.psm1
@@ -1,15 +1,39 @@
-function GetIsWindows {
+function Get-IsWindows {
     <#
     .SYNOPSIS
         Checks to see if the current machine is a Windows machine.
     
     .EXAMPLE
-        GetIsWindows
+        Get-IsWindows
 
         returns $True
     #>
 
+    # Method 1
+    # This could honestly just be the first if statement and nothing else
+    if (!$IsWindows) {
+        $IsUnix = $false
+        $IsWindows = $true
+    }elseif($IsWindows -eq $false){
+        $IsUnix = $true
+    }elseif($IsWindows -eq $true){
+        $IsUnix = $false
+    }
 
+    # Method 2
+    <#
+    $psVersion = $PSVersionTable
+    if ($psVersion.Platform -eq "Unix") {
+        $IsUnix = $true
+    }elseif (!$psVersion.Platform) {
+        $IsUnix = $false
+    }elseif($psVersion.Platform -like "*Win*"){
+        $IsUnix = $false
+    }
+    #>
+
+
+    return $IsWindows
 }
 
-Export-ModuleMember -Function "GetIsWindows"
+Export-ModuleMember -Function "Get-IsWindows"

--- a/logistics/scripts/modules/utility/cross-platform.psm1
+++ b/logistics/scripts/modules/utility/cross-platform.psm1
@@ -9,7 +9,7 @@ function Get-IsWindows {
         returns $True
     #>
 
-    if (!$IsWindows) {
+    if ($null -eq $IsWindows) {
         $IsWindows = $true
     }
 

--- a/logistics/scripts/modules/utility/cross-platform.psm1
+++ b/logistics/scripts/modules/utility/cross-platform.psm1
@@ -9,29 +9,10 @@ function Get-IsWindows {
         returns $True
     #>
 
-    # Method 1
-    # This could honestly just be the first if statement and nothing else
     if (!$IsWindows) {
         $IsUnix = $false
         $IsWindows = $true
-    }elseif($IsWindows -eq $false){
-        $IsUnix = $true
-    }elseif($IsWindows -eq $true){
-        $IsUnix = $false
     }
-
-    # Method 2
-    <#
-    $psVersion = $PSVersionTable
-    if ($psVersion.Platform -eq "Unix") {
-        $IsUnix = $true
-    }elseif (!$psVersion.Platform) {
-        $IsUnix = $false
-    }elseif($psVersion.Platform -like "*Win*"){
-        $IsUnix = $false
-    }
-    #>
-
 
     return $IsWindows
 }


### PR DESCRIPTION
This adds a new module, **cross-platform.psm1**, with a single function, **Get-IsWindows**,  to test if a machine is Windows without the automatic $IsWindows variable.

With this function, also adds:

- Validation to ensure Mono is installed on Unix-like systems
- Validation to ensure Postgres binaries are installed on Unix-like systems.

This has been tested on PS 5 on windows and PS 7.2 on Unix.
