### PR TITLE
[ODS-5402] - Add workflow for Sandbox Admin Installer

### DIFF
--- a/.github/workflows/edFi.installer.sandboxAdmin manual.yml
+++ b/.github/workflows/edFi.installer.sandboxAdmin manual.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   INFORMATIONAL_VERSION: "6.0"
-  BUILD_INCREMENTER: "1"
+  BUILD_INCREMENTER: "3"
   AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
   AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'

--- a/.github/workflows/edFi.installer.sandboxAdmin manual.yml
+++ b/.github/workflows/edFi.installer.sandboxAdmin manual.yml
@@ -18,12 +18,12 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
     - name: build
       run: |
-        .\build-package.ps1 -InformationalVersion ${{env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Publish ${{true}} -NugetFeed ${{env.AZURE_ARTIFACT_URL}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }}
+        .\build-package.ps1 -InformationalVersion ${{env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NugetFeed ${{env.AZURE_ARTIFACT_URL}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }}
       shell: pwsh
       working-directory: Scripts/NuGet/EdFi.Installer.SandboxAdmin

--- a/.github/workflows/edFi.installer.sandboxAdmin manual.yml
+++ b/.github/workflows/edFi.installer.sandboxAdmin manual.yml
@@ -1,0 +1,29 @@
+name: EdFi.Installer.SandboxAdmin Manually triggered build
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+
+env:
+  INFORMATIONAL_VERSION: "6.0"
+  BUILD_INCREMENTER: "1"
+  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+    - name: build
+      run: |
+        .\build-package.ps1 -InformationalVersion ${{env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -Publish ${{true}} -NugetFeed ${{env.AZURE_ARTIFACT_URL}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }}
+      shell: pwsh
+      working-directory: Scripts/NuGet/EdFi.Installer.SandboxAdmin

--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/EdFi.Installer.SandboxAdmin.nuspec
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/EdFi.Installer.SandboxAdmin.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>EdFi.Installer.SandboxAdmin</id>
+    <id>EdFi.Suite3.Installer.SandboxAdmin</id>
     <version>1.0.0</version>
     <title>Ed-Fi SwaggerUI Installer Scripts</title>
     <authors>Ed-Fi Alliance</authors>

--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/build-package.ps1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/build-package.ps1
@@ -5,12 +5,18 @@
 
 #requires -version 5
 param (
+    # Informational version number, defaults 1.0    
     [string]
     [Parameter(Mandatory = $true)]
-    $SemanticVersion,
+    $InformationalVersion = "1.0",
 
+    # Build counter from the automation tool, defaults to 1
     [string]
-    $BuildCounter,
+    $BuildCounter = "1",
+
+    # Build incrementer to add to the build counter to offset number from TeamCity builds, defaults to 0
+    [string]
+    $BuildIncrementer = "0",
 
     [string]
     $PreReleaseLabel,
@@ -42,6 +48,6 @@ $parameters = @{
     ToolsPath             = "../../../tools"
 }
 
-if ($BuildCounter) { $parameters.Suffix = "$PreReleaseLabel$($BuildCounter.PadLeft(4,'0'))" }
+if ($PreReleaseLabel) { $parameters.Suffix = "$PreReleaseLabel$($BuildCounter.PadLeft(4,'0'))" }
 
 Invoke-CreatePackage @parameters -Verbose:$verbose

--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/build-package.ps1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/build-package.ps1
@@ -19,12 +19,6 @@ param (
     $BuildIncrementer = "0",
 
     [string]
-    $PreReleaseLabel,
-
-    [switch]
-    $Publish,
-
-    [string]
     $NuGetFeed,
 
     [string]
@@ -38,16 +32,17 @@ $verbose = $PSCmdlet.MyInvocation.BoundParameters["Verbose"]
 
 Import-Module "$PSScriptRoot/../../../logistics/scripts/modules/packaging/create-package.psm1" -Force
 
+$newRevision = ([int]$BuildCounter) + ([int]$BuildIncrementer)
+$SemanticVersion = "$InformationalVersion.$newRevision"
+
 $parameters = @{
     PackageDefinitionFile = Resolve-Path ("$PSScriptRoot/EdFi.Installer.SandboxAdmin.nuspec")
     Version               = $SemanticVersion
     OutputDirectory       = Resolve-Path $PSScriptRoot
-    Publish               = $Publish
+    Publish               = $true
     Source                = $NuGetFeed
     ApiKey                = $NuGetApiKey
     ToolsPath             = "../../../tools"
 }
-
-if ($PreReleaseLabel) { $parameters.Suffix = "$PreReleaseLabel$($BuildCounter.PadLeft(4,'0'))" }
 
 Invoke-CreatePackage @parameters -Verbose:$verbose


### PR DESCRIPTION
This differs from the previous workflows in two regards:
1. It runs on `windows-latest` instead of `ubuntu-latest` since we have not ported over the necessary Powershell scripts to be compatible with linux. 
2. There is only one workflow that is manually triggered, and not a manually triggered and pull request workflow. This matches how it existed on TeamCity.