### PR TITLE
[ODS-5434] - Fix Multiple Auth postman test failures

### DIFF
--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />

--- a/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
+++ b/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.3" />
     <PackageReference Include="EdFi.Suite3.Common" Version="6.0.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Hangfire" Version="1.7.28" />

--- a/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
+++ b/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference  Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />


### PR DESCRIPTION
All that was needed was updating the edfi.suite3.security.dataaccess package since the one being referenced before (6.0.11) was built from a branch and not main, and was from before all of the multiple auth changes were made.