### PR TITLE
[ODS-5362] Use dotnet --list-runtimes to ensure that dotnet is installed

### DIFF
--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />

--- a/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
+++ b/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.3" />
     <PackageReference Include="EdFi.Suite3.Common" Version="6.0.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />
     <PackageReference Include="Hangfire" Version="1.7.28" />

--- a/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
+++ b/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="6.0.3" />
-    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.11" />
+    <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="6.0.12" />
     <PackageReference  Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />

--- a/logistics/scripts/modules/path-resolver.psm1
+++ b/logistics/scripts/modules/path-resolver.psm1
@@ -57,23 +57,20 @@ $invertedRepositoryNames = $repositoryNames.Clone()
 #Then trims the end of the $path off at that point and returns the path. (does include $itemName)
 #in the value returned.
 function Get-AncestorItemPath ([string]$path, [string]$itemName) {
-    # Removing the toLower() conversion since it breaks Unix implementation 
-
-    # Removing the slashes since it breaks Unix implementation to search for the forward slash
-    $pos = $path.LastIndexOf($itemName)
+    $dirChar = [IO.Path]::DirectorySeparatorChar
+    $pos = $path.LastIndexOf("$($dirChar)$itemName$($dirChar)", [System.StringComparison]::OrdinalIgnoreCase)
 
     if ($pos -lt 0) {
-        # Removing the slashes since it breaks Unix implementation to search for the forward slash
-        if ($path.EndsWith($itemName)) {
-            $pos = $path.LastIndexOf($itemName)
+        if ($path.EndsWith("$($dirChar)$itemName", [System.StringComparison]::OrdinalIgnoreCase)) {
+            $pos = $path.LastIndexOf("$($dirChar)$itemName", [System.StringComparison]::OrdinalIgnoreCase)
         }
         else {
             throw "Unable to locate '$itemName' in path '$path'."
         }
     }
 
-    # Using Join-Path and removing the forward slash to be more Unix-friendly
-    $newPath = Join-Path -Path $path.Substring(0, $pos) -ChildPath $itemName
+    # Using Join-Path to be more Unix-friendly
+    $newPath = Join-Path -Path $path.Substring(0, $pos) -ChildPath "$($dirChar)$itemName"
     return (Resolve-Path $newPath)
 }
 

--- a/logistics/scripts/modules/path-resolver.psm1
+++ b/logistics/scripts/modules/path-resolver.psm1
@@ -57,22 +57,23 @@ $invertedRepositoryNames = $repositoryNames.Clone()
 #Then trims the end of the $path off at that point and returns the path. (does include $itemName)
 #in the value returned.
 function Get-AncestorItemPath ([string]$path, [string]$itemName) {
-    #Remove Case Sensitivity
-    $path = $path.ToLower()
-    $itemName = $itemName.ToLower()
+    # Removing the toLower() conversion since it breaks Unix implementation 
 
-    $pos = $path.LastIndexOf("\$itemName\")
+    # Removing the slashes since it breaks Unix implementation to search for the forward slash
+    $pos = $path.LastIndexOf($itemName)
 
     if ($pos -lt 0) {
-        if ($path.EndsWith("\$itemName")) {
-            $pos = $path.LastIndexOf("\$itemName")
+        # Removing the slashes since it breaks Unix implementation to search for the forward slash
+        if ($path.EndsWith($itemName)) {
+            $pos = $path.LastIndexOf($itemName)
         }
         else {
             throw "Unable to locate '$itemName' in path '$path'."
         }
     }
 
-    $newPath = $path.Substring(0, $pos) + "\$itemName"
+    # Using Join-Path and removing the forward slash to be more Unix-friendly
+    $newPath = Join-Path -Path $path.Substring(0, $pos) -ChildPath $itemName
     return (Resolve-Path $newPath)
 }
 

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -173,11 +173,11 @@ function Test-DotNetCore {
         # This will check both runtimes for the specific major and minor version
         # All Microsoft.AspNetCore.App runtimes with greater than or equal major and minor version
         $validAsp = ($runtimes | Where-Object {$_.Runtime -eq "Microsoft.AspNetCore.App"} `
-            | Where-Object { $_.Version.Major -ge $RequiredMajor} `
+            | Where-Object { $_.Version.Major -eq $RequiredMajor} `
             | Where-Object { $_.Version.Minor -ge $RequiredMinor})
         # All Microsoft.NETCore.App runtimes with greater than or equal major and minor version
         $validCore = ($runtimes | Where-Object {$_.Runtime -eq "Microsoft.NETCore.App"} `
-            | Where-Object { $_.Version.Major -ge $RequiredMajor} `
+            | Where-Object { $_.Version.Major -eq $RequiredMajor} `
             | Where-Object { $_.Version.Minor -ge $RequiredMinor})
 
         if (($validCore | Measure-Object | Select-Object -ExpandProperty Count) -lt 1) {

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -157,10 +157,30 @@ function Install-ToolCodeGenUtility {
 }
 
 function Test-DotNetCore {
-    $requiredMajor = 6
-    $requiredMinor = 0
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [int]
+        $requiredMajor = 6,
+        [Parameter()]
+        [int]
+        $requiredMinor = 0,
+        [Parameter()]
+        [int]
+        $requiredBuild = 4
+    )
 
     try {
+        $runtimes = Get-DotnetRuntimes
+        
+        $validMajor = ($runtimes | Where {$_.Runtime -eq "Microsoft.AspNetCore.App" -OR $_.Runtime -eq "Microsoft.NETCore.App"} | Where { $_.Version.Major -ge $requiredMajor} )
+        $validMinor = ($validMajor | Where { $_.Version.Minor -ge $requiredMinor})
+        
+        if ($validMinor.Count -lt 2) {
+            throw
+        }
+        
+        <#
         if (Get-IsWindows) {
             ($dotnet = Get-Command dotnet -ErrorAction Stop) | Out-Null
             if ($dotnet.Version.Major -lt $requiredMajor) {
@@ -193,6 +213,7 @@ function Test-DotNetCore {
             }
 
         }
+        #>
         
 
         

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -175,9 +175,9 @@ function Test-DotNetCore {
         
         # This will check both runtimes for the specific major and minor version
         # All Microsoft.AspNetCore.App runtimes with greater than or equal major and minor version
-        $validAsp = ($runtimes | Where {$_.Runtime -eq "Microsoft.AspNetCore.App"} | Where { $_.Version.Major -ge $requiredMajor} | Where { $_.Version.Minor -ge $requiredMinor})
+        $validAsp = ($runtimes | Where-Object {$_.Runtime -eq "Microsoft.AspNetCore.App"} | Where-Object { $_.Version.Major -ge $requiredMajor} | Where-Object { $_.Version.Minor -ge $requiredMinor})
         # All Microsoft.NETCore.App runtimes with greater than or equal major and minor version
-        $validCore = ($runtimes | Where {$_.Runtime -eq "Microsoft.NETCore.App"} | Where { $_.Version.Major -ge $requiredMajor} | Where { $_.Version.Minor -ge $requiredMinor})
+        $validCore = ($runtimes | Where-Object {$_.Runtime -eq "Microsoft.NETCore.App"} | Where-Object { $_.Version.Major -ge $requiredMajor} | Where-Object { $_.Version.Minor -ge $requiredMinor})
 
         if ($validCore.Count -lt 1) {
             Write-Verbose "No valid runtime versions were found for: Microsoft.NETCore.App"

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -170,12 +170,12 @@ function Test-DotNetCore {
     try {
         $runtimes = Get-DotnetRuntimes
         
-        # This will check both runtimes for the specific major and minor version
-        # All Microsoft.AspNetCore.App runtimes with greater than or equal major and minor version
+        # This will check both runtimes for the specific major and greater than or equal to minor version
+        # All Microsoft.AspNetCore.App runtimes equal to major and greater than or equal to minor version
         $validAsp = ($runtimes | Where-Object {$_.Runtime -eq "Microsoft.AspNetCore.App"} `
             | Where-Object { $_.Version.Major -eq $RequiredMajor} `
             | Where-Object { $_.Version.Minor -ge $RequiredMinor})
-        # All Microsoft.NETCore.App runtimes with greater than or equal major and minor version
+        # All Microsoft.NETCore.App runtimes equal to major and greater than or equal to minor version
         $validCore = ($runtimes | Where-Object {$_.Runtime -eq "Microsoft.NETCore.App"} `
             | Where-Object { $_.Version.Major -eq $RequiredMajor} `
             | Where-Object { $_.Version.Minor -ge $RequiredMinor})

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -173,9 +173,10 @@ function Test-DotNetCore {
     try {
         $runtimes = Get-DotnetRuntimes
         
-        # This will check both runtimes for the specific major/minor version
-        # Validate each runtime
+        # This will check both runtimes for the specific major and minor version
+        # All Microsoft.AspNetCore.App runtimes with greater than or equal major and minor version
         $validAsp = ($runtimes | Where {$_.Runtime -eq "Microsoft.AspNetCore.App"} | Where { $_.Version.Major -ge $requiredMajor} | Where { $_.Version.Minor -ge $requiredMinor})
+        # All Microsoft.NETCore.App runtimes with greater than or equal major and minor version
         $validCore = ($runtimes | Where {$_.Runtime -eq "Microsoft.NETCore.App"} | Where { $_.Version.Major -ge $requiredMajor} | Where { $_.Version.Minor -ge $requiredMinor})
 
         if ($validCore.Count -lt 1) {

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -165,20 +165,30 @@ function Test-DotNetCore {
             ($dotnet = Get-Command dotnet -ErrorAction Stop) | Out-Null
             if ($dotnet.Version.Major -lt $requiredMajor) {
                 throw
+            }else {
+                Write-Verbose "$($dotnet.Name) major version $($dotnet.Version.Major) is greater than or equal to the required: $requiredMajor."
             }
     
             if ($dotnet.Version.Major -eq $requiredMajor -and $dotnet.Version.Minor -lt $requiredMinor) {
                 throw
+            }else {
+                Write-Verbose "$($dotnet.Name) minor version $($dotnet.Version.Minor) is greater than or equal to the required: $requiredMinor."
             }
         }else{
             $runtimes = Get-DotnetRuntimes
             foreach($dotnet in $runtimes){
+                Write-Verbose "$($dotnet.Runtime) is installed at version $($dotnet.Version)."
+
                 if ($dotnet.Version.Major -lt $requiredMajor) {
                     throw
+                }else {
+                    Write-Verbose "$($dotnet.Runtime) major version $($dotnet.Version.Major) is greater than or equal to the required: $requiredMajor."
                 }
         
                 if ($dotnet.Version.Major -eq $requiredMajor -and $dotnet.Version.Minor -lt $requiredMinor) {
                     throw
+                }else {
+                    Write-Verbose "$($dotnet.Runtime) minor version $($dotnet.Version.Minor) is greater than or equal to the required: $requiredMinor."
                 }
             }
 

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -188,9 +188,6 @@ function Test-DotNetCore {
             throw
         }
 
-        
-
-        
     }
     catch {
         throw "Running scripts require .NET Core SDK $($requiredMajor).$($requiredMinor)+, available from https://dotnet.microsoft.com/download."

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -161,13 +161,10 @@ function Test-DotNetCore {
     param (
         [Parameter()]
         [int]
-        $requiredMajor = 6,
+        $RequiredMajor = 6,
         [Parameter()]
         [int]
-        $requiredMinor = 0,
-        [Parameter()]
-        [int]
-        $requiredBuild = 4
+        $RequiredMinor = 0
     )
 
     try {
@@ -175,22 +172,26 @@ function Test-DotNetCore {
         
         # This will check both runtimes for the specific major and minor version
         # All Microsoft.AspNetCore.App runtimes with greater than or equal major and minor version
-        $validAsp = ($runtimes | Where-Object {$_.Runtime -eq "Microsoft.AspNetCore.App"} | Where-Object { $_.Version.Major -ge $requiredMajor} | Where-Object { $_.Version.Minor -ge $requiredMinor})
+        $validAsp = ($runtimes | Where-Object {$_.Runtime -eq "Microsoft.AspNetCore.App"} `
+            | Where-Object { $_.Version.Major -ge $RequiredMajor} `
+            | Where-Object { $_.Version.Minor -ge $RequiredMinor})
         # All Microsoft.NETCore.App runtimes with greater than or equal major and minor version
-        $validCore = ($runtimes | Where-Object {$_.Runtime -eq "Microsoft.NETCore.App"} | Where-Object { $_.Version.Major -ge $requiredMajor} | Where-Object { $_.Version.Minor -ge $requiredMinor})
+        $validCore = ($runtimes | Where-Object {$_.Runtime -eq "Microsoft.NETCore.App"} `
+            | Where-Object { $_.Version.Major -ge $RequiredMajor} `
+            | Where-Object { $_.Version.Minor -ge $RequiredMinor})
 
-        if ($validCore.Count -lt 1) {
+        if (($validCore | Measure-Object | Select-Object -ExpandProperty Count) -lt 1) {
             Write-Verbose "No valid runtime versions were found for: Microsoft.NETCore.App"
             throw
         }
-        if ($validAsp.Count -lt 1) {
+        if (($validAsp | Measure-Object | Select-Object -ExpandProperty Count) -lt 1) {
             Write-Verbose "No valid runtime versions were found for: Microsoft.AspNetCore.App"
             throw
         }
 
     }
     catch {
-        throw "Running scripts require .NET Core SDK $($requiredMajor).$($requiredMinor)+, available from https://dotnet.microsoft.com/download."
+        throw "Running scripts require .NET Core SDK $($RequiredMajor).$($RequiredMinor)+, available from https://dotnet.microsoft.com/download."
     }
 }
 

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -173,16 +173,7 @@ function Test-DotNetCore {
     try {
         $runtimes = Get-DotnetRuntimes
         
-        # Method 1.A | This method will false positive if eg. there are 2 versions of AspNetCore but none of NetCore
-        # Validate Both at once
-        $validMajor = ($runtimes | Where {$_.Runtime -eq "Microsoft.AspNetCore.App" -OR $_.Runtime -eq "Microsoft.NETCore.App"} | Where { $_.Version.Major -ge $requiredMajor} )
-        $validMinor = ($validMajor | Where { $_.Version.Minor -ge $requiredMinor})
-        
-        if ($validMinor.Count -lt 2) {
-            throw
-        }
-
-        # Method 1.B | This will check both runtimes for the specific major/minor version
+        # This will check both runtimes for the specific major/minor version
         # Validate each runtime
         $validAsp = ($runtimes | Where {$_.Runtime -eq "Microsoft.AspNetCore.App"} | Where { $_.Version.Major -ge $requiredMajor} | Where { $_.Version.Minor -ge $requiredMinor})
         $validCore = ($runtimes | Where {$_.Runtime -eq "Microsoft.NETCore.App"} | Where { $_.Version.Major -ge $requiredMajor} | Where { $_.Version.Minor -ge $requiredMinor})
@@ -195,43 +186,7 @@ function Test-DotNetCore {
             Write-Verbose "No valid runtime versions were found for: Microsoft.AspNetCore.App"
             throw
         }
-        
 
-        <#
-        # Method 2 | Same process as before for Windows. Tests every runtime for version, doesnt check name.
-        if (Get-IsWindows) {
-            ($dotnet = Get-Command dotnet -ErrorAction Stop) | Out-Null
-            if ($dotnet.Version.Major -lt $requiredMajor) {
-                throw
-            }else {
-                Write-Verbose "$($dotnet.Name) major version $($dotnet.Version.Major) is greater than or equal to the required: $requiredMajor."
-            }
-    
-            if ($dotnet.Version.Major -eq $requiredMajor -and $dotnet.Version.Minor -lt $requiredMinor) {
-                throw
-            }else {
-                Write-Verbose "$($dotnet.Name) minor version $($dotnet.Version.Minor) is greater than or equal to the required: $requiredMinor."
-            }
-        }else{
-            $runtimes = Get-DotnetRuntimes
-            foreach($dotnet in $runtimes){
-                Write-Verbose "$($dotnet.Runtime) is installed at version $($dotnet.Version)."
-
-                if ($dotnet.Version.Major -lt $requiredMajor) {
-                    throw
-                }else {
-                    Write-Verbose "$($dotnet.Runtime) major version $($dotnet.Version.Major) is greater than or equal to the required: $requiredMajor."
-                }
-        
-                if ($dotnet.Version.Major -eq $requiredMajor -and $dotnet.Version.Minor -lt $requiredMinor) {
-                    throw
-                }else {
-                    Write-Verbose "$($dotnet.Runtime) minor version $($dotnet.Version.Minor) is greater than or equal to the required: $requiredMinor."
-                }
-            }
-
-        }
-        #>
         
 
         

--- a/logistics/scripts/modules/utility/cross-platform.psm1
+++ b/logistics/scripts/modules/utility/cross-platform.psm1
@@ -30,13 +30,16 @@ function Get-DotnetRuntimes {
     }
     
     $runtimeArray = @()
-    foreach($runtime in $data){
+    foreach($entry in $data){
         
-        $values =  $runtime.Split(" ",3)
+        $values =  $entry.Split(" ",3)
+        $runtime = $values[0]
+        $version = [Version]$values[1]
+        $path = $values[2] -replace '[][]',''
         $thisRuntime = [ordered]@{
-            "Runtime" = $values[0];
-            "Version" = $values[1];
-            "Path" = $values[2];
+            "Runtime" = $runtime;
+            "Version" = $version;
+            "Path" = $path;
         }
         $thisObject = [PSCustomObject]$thisRuntime
         $runtimeArray += $thisObject

--- a/logistics/scripts/modules/utility/cross-platform.psm1
+++ b/logistics/scripts/modules/utility/cross-platform.psm1
@@ -19,4 +19,28 @@ function Get-IsWindows {
     return $IsWindows
 }
 
-Export-ModuleMember -Function "Get-IsWindows"
+
+function Get-DotnetRuntimes {
+
+    try {
+        $data = dotnet --list-runtimes
+    }
+    catch {
+        throw "Running scripts require .NET Core SDK, available from https://dotnet.microsoft.com/download."
+    }
+    
+    $runtimeArray = @()
+    foreach($runtime in $data){
+        
+        $values =  $runtime.Split(" ",3)
+        $thisRuntime = [ordered]@{
+            "Runtime" = $values[0];
+            "Version" = $values[1];
+            "Path" = $values[2];
+        }
+        $thisObject = [PSCustomObject]$thisRuntime
+        $runtimeArray += $thisObject
+    }
+    return $runtimeArray
+}
+Export-ModuleMember -Function "Get-IsWindows","Get-DotnetRuntimes"


### PR DESCRIPTION
- Add Get-DotnetRuntimes function that returns current dotnet runtimes in a table
- Update Test-PostgreSQLBinariesInstalled to check if psql command is available
- Update Install-NuGetCli to check if mono command is available
- Update Get-AncestorItemPath to be more unix-friendly, removed searching for windows slashes
- Update Test-DotNetCore to use Get-DotnetRuntimes to test for required dotnet runtimes