### PR TITLE
[ODS-5403] - Add workflow for Swagger UI installer

### DIFF
--- a/.github/workflows/edFi.installer.swaggerUI manual.yml
+++ b/.github/workflows/edFi.installer.swaggerUI manual.yml
@@ -1,10 +1,3 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- * Licensed to the Ed-Fi Alliance under one or more agreements.
- * The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
- * See the LICENSE and NOTICES files in the project root for more information.
- */
-
 name: EdFi.Installer.SwaggerUI Manually triggered build
 
 on:

--- a/.github/workflows/edFi.installer.swaggerUI manual.yml
+++ b/.github/workflows/edFi.installer.swaggerUI manual.yml
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed to the Ed-Fi Alliance under one or more agreements.
+ * The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+ * See the LICENSE and NOTICES files in the project root for more information.
+ */
+
+name: EdFi.Installer.SwaggerUI Manually triggered build
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+
+env:
+  INFORMATIONAL_VERSION: "6.0"
+  BUILD_INCREMENTER: "3"
+  AZURE_ARTIFACT_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  AZURE_ARTIFACT_NUGET_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS : '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+    - name: build
+      run: |
+        .\build-package.ps1 -InformationalVersion ${{env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -NugetFeed ${{env.AZURE_ARTIFACT_URL}} -NuGetApiKey ${{ env.AZURE_ARTIFACT_NUGET_KEY }}
+      shell: pwsh
+      working-directory: Scripts/NuGet/EdFi.Installer.SwaggerUI

--- a/Scripts/NuGet/EdFi.Installer.SwaggerUI/EdFi.Installer.SwaggerUI.nuspec
+++ b/Scripts/NuGet/EdFi.Installer.SwaggerUI/EdFi.Installer.SwaggerUI.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>EdFi.Installer.SwaggerUI</id>
+    <id>EdFi.Suite3.Installer.SwaggerUI</id>
     <version>1.0.0</version>
     <title>Ed-Fi SwaggerUI Installer Scripts</title>
     <authors>Ed-Fi Alliance</authors>

--- a/Scripts/NuGet/EdFi.Installer.SwaggerUI/build-package.ps1
+++ b/Scripts/NuGet/EdFi.Installer.SwaggerUI/build-package.ps1
@@ -5,24 +5,24 @@
 
 #requires -version 5
 param (
+    # Informational version number, defaults 1.0    
     [string]
     [Parameter(Mandatory = $true)]
-    $SemanticVersion,
+    $InformationalVersion = "1.0",
 
+    # Build counter from the automation tool, defaults to 1
     [string]
-    $BuildCounter,
+    $BuildCounter = "1",
 
+    # Build incrementer to add to the build counter to offset number from TeamCity builds, defaults to 0
     [string]
-    $PreReleaseLabel,
-
-    [switch]
-    $Publish,
+    $BuildIncrementer = "0",
 
     [string]
     $NuGetFeed,
 
     [string]
-    $NuGetApiKey 
+    $NuGetApiKey
 )
 $ErrorActionPreference = "Stop"
 
@@ -32,16 +32,17 @@ $verbose = $PSCmdlet.MyInvocation.BoundParameters["Verbose"]
 
 Import-Module "$PSScriptRoot/../../../logistics/scripts/modules/packaging/create-package.psm1" -Force
 
+$newRevision = ([int]$BuildCounter) + ([int]$BuildIncrementer)
+$SemanticVersion = "$InformationalVersion.$newRevision"
+
 $parameters = @{
     PackageDefinitionFile = Resolve-Path ("$PSScriptRoot/EdFi.Installer.SwaggerUI.nuspec")
     Version               = $SemanticVersion
     OutputDirectory       = Resolve-Path $PSScriptRoot
-    Publish               = $Publish
+    Publish               = $true
     Source                = $NuGetFeed
     ApiKey                = $NuGetApiKey
     ToolsPath             = "../../../tools"
 }
-
-if ($BuildCounter) { $parameters.Suffix = "$PreReleaseLabel$($BuildCounter.PadLeft(4,'0'))" }
 
 Invoke-CreatePackage @parameters -Verbose:$verbose


### PR DESCRIPTION
This runs on Windows-latest like the other installers, until we complete the necessary powershell work to run on linux images.

Like the other installer there is also no pull request workflow, which matches how it existed in TeamCity, since there is no building/testing of code that happens, just building the installer package.

[This PR](https://github.com/Ed-Fi-Alliance/Ed-Fi-TeamCity-Configs/pull/53) to remove the TeamCity config should get approved/merged AFTER this PR is approved and merged.