### PR TITLE
[ODS-5367] - Remove function for selecting node version from build script

### DIFF
--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -27,10 +27,6 @@ $script:postmanFolder = (Split-Path -Parent $configurationFile)
 $script:environmentJson = (Join-Path $script:postmanFolder "environment.json")
 
 function Install-Newman {
-    $nodeVersion = Get-ValueOrDefault (Get-TeamCityParameters)['node.version'] '12.4.0'
-
-    Select-NodeVersion $nodeVersion
-
     try {
         npm install -g newman@5.2.2 newman-reporter-teamcity@0.1.12 newman-reporter-html@1.0.5
         newman --version

--- a/logistics/scripts/modules/build-management.psm1
+++ b/logistics/scripts/modules/build-management.psm1
@@ -202,16 +202,4 @@ function New-OctopusChannel {
     if (Test-TeamCityVersion) { Write-Host "##teamcity[setParameter name='octopus.release.channel' value='$channelName']" }
 }
 
-function Select-NodeVersion {
-    param(
-        [string] $version
-    )
-
-    nvm install $version
-    nvm use $version
-    Start-Sleep -Seconds 1
-    node --version
-    npm version
-}
-
 Export-ModuleMember -function * -Alias *


### PR DESCRIPTION
To replace this, a new build step called `Select Node Version` has been created on the two builds that need it [here](https://intedfitools1.msdf.org/buildConfiguration/OdsPlatform_OdsApi_OdsApiInitDevIntegrationTest?mode=builds#all-projects) and [here](https://intedfitools1.msdf.org/buildConfiguration/OdsPlatform_OdsApi_PostgreSQL_OdsApiInitDevIntegrationTest?mode=builds#all-projects).

This is an intermediate step to moving these builds over to Github Actions where we will be able to specify the version of Node to use as part of the action.