### PR TITLE
[ODS-4931] - Add task to generate ApiSdk and TestSdk as part of integration build

### DIFF
--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -70,6 +70,8 @@ function Initialize-DevelopmentEnvironment {
         Runs the Invoke-PostmanIntegrationTests task which will run the Postman integration tests in addition to the other initdev pipeline tasks.
     .parameter RunSmokeTest
         Runs the Invoke-SmokeTests task which will run the smoke tests, against the in-memory api, in addition to the other initdev pipeline tasks.
+    .parameter RunSdkGen
+        Runs the Invoke-SdkGen task which will build and run the sdk gen console
     .parameter UsePlugins
         Runs database scripts from downloaded plugin extensions in addition to extensions found in the Ed-Fi-Ods-Implementation.
     #>

--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -458,7 +458,7 @@ function Invoke-SdkGen {
     )
     
     Invoke-Task -name $MyInvocation.MyCommand.Name -task {
-        & $(Get-RepositoryResolvedPath "/logistics/scripts/Invoke-SdkGen.ps1") -generateSdkPackages $GenerateSdkPackages
+        & $(Get-RepositoryResolvedPath "logistics/scripts/Invoke-SdkGen.ps1") -generateSdkPackages $GenerateSdkPackages
     }
 }
 

--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -72,6 +72,8 @@ function Initialize-DevelopmentEnvironment {
         Runs the Invoke-SmokeTests task which will run the smoke tests, against the in-memory api, in addition to the other initdev pipeline tasks.
     .parameter RunSdkGen
         Runs the Invoke-SdkGen task which will build and run the sdk gen console
+    .parameter GenerateSdkPackages
+        Generates ApiSdk and TestSdk packages after running SdkGen
     .parameter UsePlugins
         Runs database scripts from downloaded plugin extensions in addition to extensions found in the Ed-Fi-Ods-Implementation.
     #>
@@ -102,6 +104,8 @@ function Initialize-DevelopmentEnvironment {
         [switch] $RunSmokeTest,
 
         [switch] $RunSdkGen,
+
+        [switch] $GenerateSdkPackages,
 
         [switch] $UsePlugins
     )
@@ -170,7 +174,7 @@ function Initialize-DevelopmentEnvironment {
 
         if ($RunSmokeTest) { $script:result += Invoke-SmokeTests }
 
-        if ($RunSdkGen) { $script:result += Invoke-SdkGen }
+        if ($RunSdkGen) { $script:result += Invoke-SdkGen $GenerateSdkPackages }
     }
 
     $script:result += New-TaskResult -name '-' -duration '-'
@@ -449,8 +453,12 @@ function Invoke-PostmanIntegrationTests {
 }
 
 function Invoke-SdkGen {
+    param(
+        [Boolean] $GenerateSdkPackages
+    )
+    
     Invoke-Task -name $MyInvocation.MyCommand.Name -task {
-        & (Get-RepositoryResolvedPath "logistics/scripts/Invoke-SdkGen.ps1")
+        & $(Get-RepositoryResolvedPath "/logistics/scripts/Invoke-SdkGen.ps1") -generateSdkPackages $GenerateSdkPackages
     }
 }
 

--- a/build.teamcity.ps1
+++ b/build.teamcity.ps1
@@ -26,7 +26,7 @@ $params = @{
     RunSmokeTest        = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSmokeTest'])  $true
     UsePlugins          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.usePlugins'])    $false
     RunSdkGen           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])     $false
-    GenerateSdkPackages = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateSdkPackages']) $false
+    GenerateSdkPackages = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateSdkPackages']) $true
 }
 
 Invoke-Task "Remove-EdFiDatabases" { Remove-EdFiDatabases -Force -Engine $params.Engine }

--- a/build.teamcity.ps1
+++ b/build.teamcity.ps1
@@ -26,7 +26,7 @@ $params = @{
     RunSmokeTest        = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSmokeTest'])  $true
     UsePlugins          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.usePlugins'])    $false
     RunSdkGen           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])     $true
-    GenerateSdkPackages = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateSdkPackages']) $true
+    GenerateSdkPackages = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateSdkPackages']) $false
 }
 
 Invoke-Task "Remove-EdFiDatabases" { Remove-EdFiDatabases -Force -Engine $params.Engine }

--- a/build.teamcity.ps1
+++ b/build.teamcity.ps1
@@ -25,7 +25,7 @@ $params = @{
     RunPostman          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runPostman'])    $true
     RunSmokeTest        = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSmokeTest'])  $true
     UsePlugins          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.usePlugins'])    $false
-    RunSdkGen           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])     $false
+    RunSdkGen           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])     $true
     GenerateSdkPackages = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateSdkPackages']) $true
 }
 

--- a/build.teamcity.ps1
+++ b/build.teamcity.ps1
@@ -26,6 +26,7 @@ $params = @{
     RunSmokeTest  = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSmokeTest'])  $true
     UsePlugins    = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.usePlugins'])    $false
     RunSdkGen     = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])     $false
+    GenerateSdkPackages = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateSdkPackages']) $false
 }
 
 Invoke-Task "Remove-EdFiDatabases" { Remove-EdFiDatabases -Force -Engine $params.Engine }

--- a/build.teamcity.ps1
+++ b/build.teamcity.ps1
@@ -14,18 +14,18 @@ Write-Host
 
 # Build and Test
 $params = @{
-    InstallType   = Get-ValueOrDefault                    $teamcityParameters['odsapi.build.installType']    'Sandbox'
-    OdsTokens     = Get-ValueOrDefault (ConvertTo-Array   $teamcityParameters['odsapi.build.odsTokens'])     @()
-    Engine        = Get-ValueOrDefault                    $teamcityParameters['odsapi.build.engine']         'SQLServer'
-    NoCodeGen     = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noCodeGen'])     $false
-    NoRebuild     = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noRebuild'])     $false
-    NoDeploy      = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noDeploy'])      $false
-    RunPester     = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runPester'])     $true
-    RunDotnetTest = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runDotnetTest']) $true
-    RunPostman    = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runPostman'])    $true
-    RunSmokeTest  = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSmokeTest'])  $true
-    UsePlugins    = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.usePlugins'])    $false
-    RunSdkGen     = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])     $false
+    InstallType         = Get-ValueOrDefault                    $teamcityParameters['odsapi.build.installType']    'Sandbox'
+    OdsTokens           = Get-ValueOrDefault (ConvertTo-Array   $teamcityParameters['odsapi.build.odsTokens'])     @()
+    Engine              = Get-ValueOrDefault                    $teamcityParameters['odsapi.build.engine']         'SQLServer'
+    NoCodeGen           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noCodeGen'])     $false
+    NoRebuild           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noRebuild'])     $false
+    NoDeploy            = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noDeploy'])      $false
+    RunPester           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runPester'])     $true
+    RunDotnetTest       = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runDotnetTest']) $true
+    RunPostman          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runPostman'])    $true
+    RunSmokeTest        = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSmokeTest'])  $true
+    UsePlugins          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.usePlugins'])    $false
+    RunSdkGen           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])     $false
     GenerateSdkPackages = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateSdkPackages']) $false
 }
 

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -86,25 +86,25 @@ function Invoke-Pack-ApiSdk {
         [string[]] $teamCityParameters = @()
 
     )
-    $nugetProperties = @{
-        configuration = $buildConfiguration
-        authors       = Get-ValueOrDefault $teamCityParameters['nuget.pack.properties.authors'] 'Ed-Fi Alliance'
-        owners        = Get-ValueOrDefault $teamCityParameters['nuget.pack.properties.owners'] 'Ed-Fi Alliance'
-        copyright     = Get-ValueOrDefault $teamCityParameters['nuget.pack.properties.copyright'] 'Copyright ©Ed-Fi Alliance, LLC. 2020'
-    }
+    $nugetProperties = @(
+        "configuration=$buildConfiguration",
+        "$(Get-ValueOrDefault $teamCityParameters['nuget.pack.properties.authors'] 'authors=Ed-Fi Alliance')",
+        "$(Get-ValueOrDefault $teamCityParameters['nuget.pack.properties.owners'] 'owners=Ed-Fi Alliance')",
+        "$(Get-ValueOrDefault $teamCityParameters['nuget.pack.properties.copyright'] 'copyright=Copyright ©Ed-Fi Alliance, LLC. 2020')"
+    )
 
     $nugetOutputParameter = Get-ValueOrDefault $teamCityParameters['nuget.pack.output'] "NugetPackages"
     $scriptRoot = Resolve-Path $PSScriptRoot
     $nugetOutput = (Join-Path $scriptRoot $nugetOutputParameter)
 
     $parameters = @{
-        PackageDefinitionFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/./csharp/EdFi.OdsApi.Sdk.nuspec")
+        PackageDefinitionFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.OdsApi.Sdk.nuspec")
         Version               = Get-ValueOrDefault $teamCityParameters['version'] '0.0.0'
         OutputDirectory       = $nugetOutput
         Publish               = $false
         ToolsPath             = "../../../tools"
         Properties            = $nugetProperties
-        AdditionalParameters  = Get-ValueOrDefault $teamCityParameters['nuget.pack.parameters'] '-NoPackageAnalysis -NoDefaultExcludes'
+        #AdditionalParameters  = Get-ValueOrDefault $teamCityParameters['nuget.pack.parameters'] '-NoPackageAnalysis -NoDefaultExcludes'
     }
     
     Invoke-CreatePackage @parameters -Verbose:$verbose

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -53,7 +53,7 @@ function Invoke-SdkGen {
             $script:result += Invoke-Task -name "Stop-TestHarness" -task { Stop-TestHarness }
         }
 
-        $sdkSolutionFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/./csharp/EdFi.OdsApi.Sdk.sln")
+        $sdkSolutionFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln")
         $script:result += Invoke-Task "Restore-ApiSdk-Packages" { Invoke-Restore-ApiSdk-Packages $sdkSolutionFile }
         $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal" $sdkSolutionFile }
         $script:result += Invoke-Task "Pack-ApiSdk" { Invoke-Pack-ApiSdk $buildConfiguration $teamCityParameters }
@@ -70,8 +70,7 @@ function Invoke-Restore-ApiSdk-Packages {
     param (
         [string] $sdkSolutionFile
     )
-    $implementationRepo = Get-Item "$PSScriptRoot/../.." | Select-Object -Expand Name
-    $toolsPath = (Join-Path (Get-RepositoryRoot $implementationRepo) 'tools')
+    $toolsPath = (Join-Path (Get-RepositoryRoot "ed-fi-ods-implementation") 'tools')
 
     $params = @{
         SolutionPath = $sdkSolutionFile
@@ -87,9 +86,7 @@ function Invoke-Pack-ApiSdk {
 
     )
 
-    $nugetOutputParameter = Get-ValueOrDefault $teamCityParameters['nuget.pack.output'] "NugetPackages"
-    $scriptRoot = Resolve-Path $PSScriptRoot
-    $nugetOutput = (Join-Path $scriptRoot $nugetOutputParameter)
+    $nugetOutput = Get-ValueOrDefault $teamCityParameters['%nuget.pack.output%'] 'NugetPackages'
 
     $parameters = @{
         PackageDefinitionFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.OdsApi.Sdk.nuspec")

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -69,7 +69,7 @@ function Invoke-Restore-ApiSdk-Packages {
     $toolsPath = (Join-Path (Get-RepositoryRoot $implementationRepo) 'tools')
 
     $params = @{
-        SolutionPath = "$(Get-RepositoryResolvedPath "\Utilities\SdkGen\EdFi.SdkGen.Console\bin\$buildConfiguration\**\.\csharp\EdFi.OdsApi.Sdk.sln")"
+        SolutionPath = "$(Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/bin/$buildConfiguration/**/./csharp/EdFi.OdsApi.Sdk.sln")"
         ToolsPath = $toolsPath
     }
     Restore-Packages @params

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -51,7 +51,7 @@ function Invoke-SdkGen {
             $script:result += Invoke-Task -name "Stop-TestHarness" -task { Stop-TestHarness }
         }
 
-        $script:result += Invoke-Task "Restore-ApiSdk-Packages" { Invoke-Restore-ApiSdk-Packages $buildConfiguration }
+        $script:result += Invoke-Task "Restore-ApiSdk-Packages" { Invoke-Restore-ApiSdk-Packages }
     }
 
     Test-Error
@@ -62,14 +62,11 @@ function Invoke-SdkGen {
 }
 
 function Invoke-Restore-ApiSdk-Packages {
-    Param(
-        [string] $buildConfiguration = "Debug"
-    )
     $implementationRepo = Get-Item "$PSScriptRoot/../.." | Select-Object -Expand Name
     $toolsPath = (Join-Path (Get-RepositoryRoot $implementationRepo) 'tools')
 
     $params = @{
-        SolutionPath = "$(Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/bin/$buildConfiguration/**/./csharp/EdFi.OdsApi.Sdk.sln")"
+        SolutionPath = "$(Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/./csharp/EdFi.OdsApi.Sdk.sln")"
         ToolsPath = $toolsPath
     }
     Restore-Packages @params

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -33,6 +33,7 @@ Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'Initialize-Power
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/TestHarness.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/packaging/restore-packages.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/packaging/create-package.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/settings/settings-management.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/settings/settings-teamcity.psm1')
 
 function Invoke-SdkGen {
@@ -92,7 +93,9 @@ function Invoke-Pack-ApiSdk {
         copyright     = Get-ValueOrDefault $teamCityParameters['nuget.pack.properties.copyright'] 'Copyright ©Ed-Fi Alliance, LLC. 2020'
     }
 
-    $nugetOutput = (Join-Path Resolve-Path $PSScriptRoot Get-ValueOrDefault $teamCityParameters['nuget.pack.output'] "NugetPackages")
+    $nugetOutputParameter = Get-ValueOrDefault $teamCityParameters['nuget.pack.output'] "NugetPackages"
+    $scriptRoot = Resolve-Path $PSScriptRoot
+    $nugetOutput = (Join-Path $scriptRoot $nugetOutputParameter)
 
     $parameters = @{
         PackageDefinitionFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/./csharp/EdFi.OdsApi.Sdk.nuspec")

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -48,6 +48,7 @@ function Invoke-SdkGen {
     
     $elapsed = Use-StopWatch {
         try {
+            $script:result += Invoke-Task "Clean-SdkGen-Console-Output" { Invoke-Clean-SdkGen-Output }
             $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal"  $sdkGenSolution }
             $script:result += Invoke-Task -name "Start-TestHarness" -task { Start-TestHarness $apiUrl $configurationFile $environmentFilePath }
             $sdkCliVersion = Get-ValueOrDefault $teamCityParameters['SdkCliVersion'] '5.4.0'
@@ -135,7 +136,13 @@ function Invoke-Pack-ApiSdk {
 }
 
 function Invoke-Clean-SdkGen-Output {
-    Remove-Item (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/csharp") -Recurse
+    try {
+        Remove-Item (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/csharp") -Recurse
+    }
+    catch {
+        # catching if this call throws, which just means the path does not exist so sdkgen has not been run yet
+    }
+    
 }
 
 Invoke-SdkGen

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -32,13 +32,14 @@ Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/script
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'Initialize-PowershellForDevelopment.ps1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/TestHarness.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/packaging/restore-packages.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/settings/settings-teamcity.psm1')
 
 function Invoke-SdkGen {
     $script:result = @()
     $sdkGenSolution = (Get-RepositoryResolvedPath "Utilities\SdkGen\EdFi.SdkGen.sln")
     $apiMetadataUrl = ($apiUrl + "/metadata?sdk=true")
-    $buildConfiguration = "Debug"
-    if (-not [string]::IsNullOrWhiteSpace($env:msbuild_buildConfiguration)) { $buildConfiguration = $env:msbuild_buildConfiguration }
+    $teamcityParameters = Get-TeamCityParameters
+    $buildConfiguration = Get-ValueOrDefault $teamcityParameters['msbuild.buildConfiguration'] 'Debug'
     
     $elapsed = Use-StopWatch {
         try {

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -86,12 +86,6 @@ function Invoke-Pack-ApiSdk {
         [string[]] $teamCityParameters = @()
 
     )
-    $nugetProperties = @(
-        "configuration=$buildConfiguration",
-        "$(Get-ValueOrDefault $teamCityParameters['nuget.pack.properties.authors'] 'authors=Ed-Fi Alliance')",
-        "$(Get-ValueOrDefault $teamCityParameters['nuget.pack.properties.owners'] 'owners=Ed-Fi Alliance')",
-        "$(Get-ValueOrDefault $teamCityParameters['nuget.pack.properties.copyright'] 'copyright=Copyright ©Ed-Fi Alliance, LLC. 2020')"
-    )
 
     $nugetOutputParameter = Get-ValueOrDefault $teamCityParameters['nuget.pack.output'] "NugetPackages"
     $scriptRoot = Resolve-Path $PSScriptRoot
@@ -103,8 +97,7 @@ function Invoke-Pack-ApiSdk {
         OutputDirectory       = $nugetOutput
         Publish               = $false
         ToolsPath             = "../../../tools"
-        Properties            = $nugetProperties
-        #AdditionalParameters  = Get-ValueOrDefault $teamCityParameters['nuget.pack.parameters'] '-NoPackageAnalysis -NoDefaultExcludes'
+        Properties            = @("configuration=$buildConfiguration")
     }
     
     Invoke-CreatePackage @parameters -Verbose:$verbose

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -39,7 +39,6 @@ Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/script
 
 function Invoke-SdkGen {
     $script:result = @()
-    Write-Host "GenerateSdkPackages: $GenerateSdkPackages"
     $sdkGenSolution = (Get-RepositoryResolvedPath "Utilities\SdkGen\EdFi.SdkGen.sln")
     $apiMetadataUrl = ($apiUrl + "/metadata?sdk=true")
     $teamCityParameters = Get-TeamCityParameters

--- a/logistics/scripts/modules/TestHarness.psm1
+++ b/logistics/scripts/modules/TestHarness.psm1
@@ -74,12 +74,15 @@ function Get-SdkGenExecutable {
 function Invoke-SdkGenConsole {
     Param(
         [Parameter(Mandatory = $true)] [string] $apiMetadataUrl,
-        [string] $buildConfiguration = "Debug"
+        [string] $buildConfiguration = "Debug",
+        [string[]] $arguments = @("-p","-c","-i")
+
     )
     
     $sdkGenConsoleFolder = (Get-RepositoryResolvedPath "/Utilities/SdkGen/EdFi.SdkGen.Console")
     $sdkGenConsoleExecutableFolderFullPath = (Get-SdkGenExecutable $buildConfiguration)
-    Start-Process $sdkGenConsoleExecutableFolderFullPath -ArgumentList @('-m', $apiMetadataUrl, '-p', '-c', '-i') -WorkingDirectory $sdkGenConsoleFolder -NoNewWindow -Wait | Out-Host
+    $argumentList = @('-m', $apiMetadataUrl) + $arguments
+    Start-Process $sdkGenConsoleExecutableFolderFullPath -ArgumentList $argumentList -WorkingDirectory $sdkGenConsoleFolder -NoNewWindow -Wait | Out-Host
 }
 
 function Start-TestHarness {

--- a/logistics/scripts/modules/packaging/create-package.psm1
+++ b/logistics/scripts/modules/packaging/create-package.psm1
@@ -87,7 +87,6 @@ function Invoke-CreatePackage {
         NuGet                 = $nuget
         Verbose               = $verbose
         Properties            = $Properties
-        AdditionalParameters  = $AdditionalParameters
     }
     New-Package @parameters
 
@@ -141,10 +140,7 @@ function New-Package {
 
         [string]
         [Parameter(Mandatory = $true)]
-        $NuGet,
-
-        [string]
-        $AdditionalParameters
+        $NuGet
     )
 
     $parameters = @(
@@ -166,10 +162,6 @@ function New-Package {
     if ($Verbose) {
         $parameters += "-Verbosity"
         $parameters += "detailed"
-    }
-
-    if($AdditionalParameters) {
-        $parameters += $AdditionalParameters
     }
 
     Write-Host $NuGet @parameters -ForegroundColor Magenta

--- a/logistics/scripts/modules/packaging/create-package.psm1
+++ b/logistics/scripts/modules/packaging/create-package.psm1
@@ -65,7 +65,14 @@ function Invoke-CreatePackage {
 
         # Path to download and store nuget.exe if not already present in the path.
         [string]
-        $ToolsPath
+        $ToolsPath,
+
+        # Additional Properties to pass to nuget.exe
+        [string[]]
+        $Properties = @(),
+
+        [string]
+        $AdditionalParameters
     )
 
     $verbose = $PSCmdlet.MyInvocation.BoundParameters["Verbose"]
@@ -79,6 +86,8 @@ function Invoke-CreatePackage {
         OutputDirectory       = $OutputDirectory
         NuGet                 = $nuget
         Verbose               = $verbose
+        Properties            = $Properties
+        AdditionalParameters  = $AdditionalParameters
     }
     New-Package @parameters
 
@@ -132,7 +141,10 @@ function New-Package {
 
         [string]
         [Parameter(Mandatory = $true)]
-        $NuGet
+        $NuGet,
+
+        [string]
+        $AdditionalParameters
     )
 
     $parameters = @(
@@ -154,6 +166,10 @@ function New-Package {
     if ($Verbose) {
         $parameters += "-Verbosity"
         $parameters += "detailed"
+    }
+
+    if($AdditionalParameters) {
+        $parameters += $AdditionalParameters
     }
 
     Write-Host $NuGet @parameters -ForegroundColor Magenta


### PR DESCRIPTION
Now the InitDev builds in TeamCity will run SdkGen and also generate the ApiSdk and TestSdk Packages. To accomplish this, a new build parameter was added `odsapi.build.generateSdkPackages` and when set to true, it will generate the two sdk packages after SdkGen has been run. In TeamCity the initdev builds also had the parameter `odsapi.build.runSdkGen` set to true since that is required for generating these two packages. Currently both initdev builds have this new parameter set to false, and the build.teamcity.ps1 will set this value to false if a value is not pulled from TeamCity.

One thing to note is that SdkGen and GenreateSdkPackages tasks will not be executed as part of initdev for local development, so if you want to test this script locally, you would need to make sure they are set to true to see the results of those tasks.