### PR TITLE
[ODS-5485] [ODS-5481] Improve use of X-Forwarded-XYZ headers (5.3)

### DIFF
--- a/Application/EdFi.Ods.WebApi/appsettings.json
+++ b/Application/EdFi.Ods.WebApi/appsettings.json
@@ -18,6 +18,8 @@
     "Mode": "sandbox",
     "Engine": "SQLServer",
     "UseReverseProxyHeaders": false,
+    "OverrideForForwardingHostServer": "",
+    "OverrideForForwardingHostPort": "",
     "PathBase": "",
     "MinimalTemplateSuffix": "Ods_Minimal_Template",
     "PopulatedTemplateSuffix": "Ods_Populated_Template",


### PR DESCRIPTION
* Introduce appsettings for default X-Forwarded-Host
and X-Forwarded-Port in case they are not included

* Refactor from "default" to "overrideFor"

Co-authored-by: Axel Marquez <axel_marqz@hotmail.com>