### PR TITLE
[ODS-5512] Support PS 7.2 and Unix - Script group 2

### DIFF
--- a/logistics/scripts/modules/load-path-resolver.ps1
+++ b/logistics/scripts/modules/load-path-resolver.ps1
@@ -9,7 +9,7 @@ param(
 
 if ((Get-Module | Where-Object -Property Name -eq 'path-resolver')) { return }
 
-Import-Module -Force -Scope Global "$PSScriptRoot\path-resolver.psm1" -ArgumentList @(, $repositoryNames)
+Import-Module -Force -Scope Global "$PSScriptRoot/path-resolver.psm1" -ArgumentList @(, $repositoryNames)
 
 # sanity check to make sure all repositories exist
 Get-RepositoryResolvedPath

--- a/logistics/scripts/modules/packaging/create-package.psm1
+++ b/logistics/scripts/modules/packaging/create-package.psm1
@@ -7,7 +7,7 @@
 
 $ErrorActionPreference = "Stop"
 
-Import-Module -Force -Scope Global "$PSScriptRoot\nuget-helper.psm1"
+Import-Module -Force -Scope Global "$PSScriptRoot/nuget-helper.psm1"
 
 function Invoke-CreatePackage {
     <#
@@ -165,7 +165,11 @@ function New-Package {
     }
 
     Write-Host $NuGet @parameters -ForegroundColor Magenta
-    & $NuGet @parameters
+    if(Get-isWindows){
+        & $NuGet @parameters
+    }else {
+        mono $NuGet @parameters
+    }
 }
 
 
@@ -197,7 +201,11 @@ function Publish-PrereleasePackage {
     }
 
     Write-Host $NuGet @parameters -ForegroundColor Magenta
-    & $NuGet @parameters
+    if(Get-isWindows){
+        & $NuGet @parameters
+    }else {
+        mono $NuGet @parameters
+    }
 }
 
 Export-ModuleMember -Function Invoke-CreatePackage, New-Package

--- a/logistics/scripts/modules/packaging/restore-packages.psm1
+++ b/logistics/scripts/modules/packaging/restore-packages.psm1
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-Import-Module -Force -Scope Global "$PSScriptRoot\nuget-helper.psm1"
+Import-Module -Force -Scope Global "$PSScriptRoot/nuget-helper.psm1"
 
 function Restore-Packages {
     <#
@@ -28,7 +28,14 @@ function Restore-Packages {
 
     Install-NuGetCli -toolsPath $toolsPath
 
-    & nuget restore $solutionPath | Write-Host
+    if(Get-IsWindows){
+        $nuget = Join-Path $toolsPath "nuget"
+        & $nuget restore $solutionPath | Write-Host
+        
+    }else {
+        $nuget = Join-Path $toolsPath "nuget.exe"
+        & mono $nuget restore $solutionPath | Write-Host
+    }
     & dotnet restore $solutionPath | Write-Host
 }
 


### PR DESCRIPTION
Fixed unix pathing for the following files.

- restore-packages.psm1
- create-package.psm1
- load-path-resolver.ps1

Also check for windows and use mono if not for nuget restore