### PR TITLE
ODS-5568 - Create separate parameters for creating apisdk and testsdk packages

### DIFF
--- a/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -92,7 +92,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateSdkPackages -NoPackaging
+        .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -NoPackaging
       shell: pwsh
     - name: Upload initdev logs
       if: success() || failure()

--- a/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -92,7 +92,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -NoPackaging
+        .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateTestSdkPackage -NoPackaging
       shell: pwsh
     - name: Upload initdev logs
       if: success() || failure()

--- a/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
+++ b/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
@@ -90,7 +90,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateSdkPackages -RunPostman -RunPester -RunDotnetTest -NoPackaging
+        .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -NoPackaging
       shell: pwsh
     - name: Upload initdev logs
       if: success() || failure()

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -114,7 +114,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateSdkPackages -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -RunSmokeTest -PackageOutput "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/NugetPackages"
+        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -RunSmokeTest -PackageOutput "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/NugetPackages"
       shell: pwsh
     - name: Upload initdev logs
       if: success() || failure()

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -114,7 +114,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateSdkPackages -RunPostman -RunPester -RunDotnetTest -RunSmokeTest -PackageOutput "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/NugetPackages"
+        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateSdkPackages -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -RunSmokeTest -PackageOutput "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/NugetPackages"
       shell: pwsh
     - name: Upload initdev logs
       if: success() || failure()

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -113,7 +113,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -NoPackaging
+        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateTestSdkPackage -NoPackaging
       shell: pwsh
     - name: Upload initdev logs
       if: success() || failure()

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -116,7 +116,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateSdkPackages -GenerateTestSdkPackage -NoPackaging
+        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -NoPackaging
       shell: pwsh
     - name: Upload initdev logs
       if: success() || failure()

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -116,7 +116,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateSdkPackages -NoPackaging
+        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateSdkPackages -GenerateTestSdkPackage -NoPackaging
       shell: pwsh
     - name: Upload initdev logs
       if: success() || failure()

--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -72,7 +72,7 @@ function Initialize-DevelopmentEnvironment {
         Runs the Invoke-SmokeTests task which will run the smoke tests, against the in-memory api, in addition to the other initdev pipeline tasks.
     .parameter RunSdkGen
         Runs the Invoke-SdkGen task which will build and run the sdk gen console
-    .parameter GenerateSdkPackages
+    .parameter GenerateApiSdkPackage
         Generates ApiSdk package after running SdkGen
     .parameter GenerateTestSdkPackage
         Generates TestSdk package after running SdkGen
@@ -109,7 +109,7 @@ function Initialize-DevelopmentEnvironment {
 
         [switch] $RunSdkGen,
 
-        [switch] $GenerateSdkPackages,
+        [switch] $GenerateApiSdkPackage,
 
         [switch] $GenerateTestSdkPackage,
 
@@ -185,7 +185,7 @@ function Initialize-DevelopmentEnvironment {
 
         if ($RunSmokeTest) { $script:result += Invoke-SmokeTests }
 
-        if ($RunSdkGen) { $script:result += Invoke-SdkGen $GenerateSdkPackages $GenerateTestSdkPackage $PackageVersion }
+        if ($RunSdkGen) { $script:result += Invoke-SdkGen $GenerateApiSdkPackage $GenerateTestSdkPackage $PackageVersion }
     }
 
     $script:result += New-TaskResult -name '-' -duration '-'
@@ -482,13 +482,13 @@ function Invoke-PostmanIntegrationTests {
 
 function Invoke-SdkGen {
     param(
-        [Boolean] $GenerateSdkPackages,
+        [Boolean] $GenerateApiSdkPackage,
         [Boolean] $GenerateTestSdkPackage,
         [string] $PackageVersion
     )
     
     Invoke-Task -name $MyInvocation.MyCommand.Name -task {
-        & $(Get-RepositoryResolvedPath "logistics/scripts/Invoke-SdkGen.ps1") -generateSdkPackages $GenerateSdkPackages -packageVersion $PackageVersion
+        & $(Get-RepositoryResolvedPath "logistics/scripts/Invoke-SdkGen.ps1") -generateApiSdkPackage $GenerateApiSdkPackage -generateTestSdkPackage $GenerateTestSdkPackage -packageVersion $PackageVersion
     }
 }
 

--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -73,7 +73,9 @@ function Initialize-DevelopmentEnvironment {
     .parameter RunSdkGen
         Runs the Invoke-SdkGen task which will build and run the sdk gen console
     .parameter GenerateSdkPackages
-        Generates ApiSdk and TestSdk packages after running SdkGen
+        Generates ApiSdk package after running SdkGen
+    .parameter GenerateTestSdkPackage
+        Generates TestSdk package after running SdkGen
     .parameter UsePlugins
         Runs database scripts from downloaded plugin extensions in addition to extensions found in the Ed-Fi-Ods-Implementation.
     .parameter PackageVersion
@@ -108,6 +110,8 @@ function Initialize-DevelopmentEnvironment {
         [switch] $RunSdkGen,
 
         [switch] $GenerateSdkPackages,
+
+        [switch] $GenerateTestSdkPackage,
 
         [switch] $UsePlugins,
 
@@ -181,7 +185,7 @@ function Initialize-DevelopmentEnvironment {
 
         if ($RunSmokeTest) { $script:result += Invoke-SmokeTests }
 
-        if ($RunSdkGen) { $script:result += Invoke-SdkGen $GenerateSdkPackages $PackageVersion }
+        if ($RunSdkGen) { $script:result += Invoke-SdkGen $GenerateSdkPackages $GenerateTestSdkPackage $PackageVersion }
     }
 
     $script:result += New-TaskResult -name '-' -duration '-'
@@ -479,6 +483,7 @@ function Invoke-PostmanIntegrationTests {
 function Invoke-SdkGen {
     param(
         [Boolean] $GenerateSdkPackages,
+        [Boolean] $GenerateTestSdkPackage,
         [string] $PackageVersion
     )
     

--- a/build.github.ps1
+++ b/build.github.ps1
@@ -58,28 +58,28 @@ $ErrorActionPreference = 'Stop'
 
 # Build and Test
 $params = @{
-    InstallType         = $InstallType
-    OdsTokens           = @()
-    Engine              = $Engine
-    NoCodeGen           = $NoCodeGen
-    NoRebuild           = $NoRebuild
-    NoDeploy            = $NoDeploy
-    RunPester           = $RunPester
-    RunDotnetTest       = $RunDotnetTest
-    RunPostman          = $RunPostman
-    RunSmokeTest        = $RunSmokeTest
-    UsePlugins          = $UsePlugins
-    RunSdkGen           = $RunSdkGen
-    GenerateApiSdkPackage = $GenerateApiSdkPackage
+    InstallType            = $InstallType
+    OdsTokens              = @()
+    Engine                 = $Engine
+    NoCodeGen              = $NoCodeGen
+    NoRebuild              = $NoRebuild
+    NoDeploy               = $NoDeploy
+    RunPester              = $RunPester
+    RunDotnetTest          = $RunDotnetTest
+    RunPostman             = $RunPostman
+    RunSmokeTest           = $RunSmokeTest
+    UsePlugins             = $UsePlugins
+    RunSdkGen              = $RunSdkGen
+    GenerateApiSdkPackage  = $GenerateApiSdkPackage
     GenerateTestSdkPackage = $GenerateTestSdkPackage
-    NoPackaging         = $NoPackaging
-    SandboxAdminId      = $SandboxAdminId
-    PackageVersion      = $PackageVersion
-    PackageOutput       = $PackageOutput
-    SwaggerUIId         = $SwaggerUIId
-    WebApiId            = $WebApiId
-    DatabasesId         = $DatabasesId
-    RepositoryRoot      = $RepositoryRoot
+    NoPackaging            = $NoPackaging
+    SandboxAdminId         = $SandboxAdminId
+    PackageVersion         = $PackageVersion
+    PackageOutput          = $PackageOutput
+    SwaggerUIId            = $SwaggerUIId
+    WebApiId               = $WebApiId
+    DatabasesId            = $DatabasesId
+    RepositoryRoot         = $RepositoryRoot
 }
 
 Write-FlatHashtable $params

--- a/build.github.ps1
+++ b/build.github.ps1
@@ -30,6 +30,8 @@ param(
 
     [switch] $GenerateSdkPackages = $false,
 
+    [switch] $GenerateTestSdkPackages = $false,
+
     [switch] $UsePlugins = $false,
 
     [switch] $NoPackaging = $false,
@@ -69,6 +71,7 @@ $params = @{
     UsePlugins          = $UsePlugins
     RunSdkGen           = $RunSdkGen
     GenerateSdkPackages = $GenerateSdkPackages
+    GenerateTestSdkPackage = $GenerateTestSdkPackage
     NoPackaging         = $NoPackaging
     SandboxAdminId      = $SandboxAdminId
     PackageVersion      = $PackageVersion

--- a/build.github.ps1
+++ b/build.github.ps1
@@ -28,9 +28,9 @@ param(
 
     [switch] $RunSdkGen = $false,
 
-    [switch] $GenerateSdkPackages = $false,
+    [switch] $GenerateApiSdkPackage = $false,
 
-    [switch] $GenerateTestSdkPackages = $false,
+    [switch] $GenerateTestSdkPackage = $false,
 
     [switch] $UsePlugins = $false,
 
@@ -70,7 +70,7 @@ $params = @{
     RunSmokeTest        = $RunSmokeTest
     UsePlugins          = $UsePlugins
     RunSdkGen           = $RunSdkGen
-    GenerateSdkPackages = $GenerateSdkPackages
+    GenerateApiSdkPackage = $GenerateApiSdkPackage
     GenerateTestSdkPackage = $GenerateTestSdkPackage
     NoPackaging         = $NoPackaging
     SandboxAdminId      = $SandboxAdminId

--- a/build.teamcity.ps1
+++ b/build.teamcity.ps1
@@ -26,8 +26,8 @@ $params = @{
     RunSmokeTest        = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSmokeTest'])  $true
     UsePlugins          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.usePlugins'])    $false
     RunSdkGen           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])     $true
-    GenerateApiSdkPackage = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateApiSdkPackage']) $true
-    GenerateTestSdkPackage = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateTestSdkPackage']) $true
+    GenerateApiSdkPackage = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateApiSdkPackage']) $false
+    GenerateTestSdkPackage = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateTestSdkPackage']) $false
 }
 
 Invoke-Task "Remove-EdFiDatabases" { Remove-EdFiDatabases -Force -Engine $params.Engine }

--- a/build.teamcity.ps1
+++ b/build.teamcity.ps1
@@ -26,7 +26,7 @@ $params = @{
     RunSmokeTest        = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSmokeTest'])  $true
     UsePlugins          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.usePlugins'])    $false
     RunSdkGen           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])     $true
-    GenerateSdkPackages = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateSdkPackages']) $true
+    GenerateApiSdkPackage = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateApiSdkPackage']) $true
     GenerateTestSdkPackage = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateTestSdkPackage']) $true
 }
 

--- a/build.teamcity.ps1
+++ b/build.teamcity.ps1
@@ -26,7 +26,8 @@ $params = @{
     RunSmokeTest        = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSmokeTest'])  $true
     UsePlugins          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.usePlugins'])    $false
     RunSdkGen           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])     $true
-    GenerateSdkPackages = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateSdkPackages']) $false
+    GenerateSdkPackages = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateSdkPackages']) $true
+    GenerateTestSdkPackage = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateTestSdkPackage']) $true
 }
 
 Invoke-Task "Remove-EdFiDatabases" { Remove-EdFiDatabases -Force -Engine $params.Engine }

--- a/build.teamcity.ps1
+++ b/build.teamcity.ps1
@@ -14,19 +14,19 @@ Write-Host
 
 # Build and Test
 $params = @{
-    InstallType         = Get-ValueOrDefault                    $teamcityParameters['odsapi.build.installType']    'Sandbox'
-    OdsTokens           = Get-ValueOrDefault (ConvertTo-Array   $teamcityParameters['odsapi.build.odsTokens'])     @()
-    Engine              = Get-ValueOrDefault                    $teamcityParameters['odsapi.build.engine']         'SQLServer'
-    NoCodeGen           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noCodeGen'])     $false
-    NoRebuild           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noRebuild'])     $false
-    NoDeploy            = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noDeploy'])      $false
-    RunPester           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runPester'])     $true
-    RunDotnetTest       = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runDotnetTest']) $true
-    RunPostman          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runPostman'])    $true
-    RunSmokeTest        = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSmokeTest'])  $true
-    UsePlugins          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.usePlugins'])    $false
-    RunSdkGen           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])     $true
-    GenerateApiSdkPackage = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateApiSdkPackage']) $false
+    InstallType            = Get-ValueOrDefault                    $teamcityParameters['odsapi.build.installType']             'Sandbox'
+    OdsTokens              = Get-ValueOrDefault (ConvertTo-Array   $teamcityParameters['odsapi.build.odsTokens'])              @()
+    Engine                 = Get-ValueOrDefault                    $teamcityParameters['odsapi.build.engine']                  'SQLServer'
+    NoCodeGen              = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noCodeGen'])              $false
+    NoRebuild              = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noRebuild'])              $false
+    NoDeploy               = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.noDeploy'])               $false
+    RunPester              = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runPester'])              $true
+    RunDotnetTest          = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runDotnetTest'])          $true
+    RunPostman             = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runPostman'])             $true
+    RunSmokeTest           = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSmokeTest'])           $true
+    UsePlugins             = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.usePlugins'])             $false
+    RunSdkGen              = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.runSdkGen'])              $true
+    GenerateApiSdkPackage  = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateApiSdkPackage'])  $false
     GenerateTestSdkPackage = Get-ValueOrDefault (ConvertTo-Boolean $teamcityParameters['odsapi.build.generateTestSdkPackage']) $false
 }
 

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -99,10 +99,7 @@ function Invoke-SdkGen {
             $suffix = Get-ValueOrDefault $teamCityParameters['odsapi.package.suffix'] ".Suite3"
             Write-Host "Updating package id and title to EdFi$suffix.OdsApi.TestSdk"
             (Get-Content -path $nuspecFile -Raw) | ForEach-Object {
-                $_.replace("<id>EdFi.OdsApi.Sdk</id>","<id>EdFi$suffix.OdsApi.TestSdk</id>").replace("<title>EdFi.OdsApi.Sdk</title>","<title>EdFi$suffix.OdsApi.TestSdk</title>")
-            } | Set-Content -Path $nuspecFile
-            (Get-Content -path $nuspecFile -Raw) | ForEach-Object {
-                $_.replace("<id>EdFi$suffix.OdsApi.Sdk</id>","<id>EdFi$suffix.OdsApi.TestSdk</id>").replace("<title>EdFi$suffix.OdsApi.Sdk</title>","<title>EdFi$suffix.OdsApi.TestSdk</title>")
+                $_.replace("<id>EdFi.OdsApi.Sdk</id>","<id>EdFi$suffix.OdsApi.TestSdk</id>").replace("<title>EdFi.OdsApi.Sdk</title>","<title>EdFi$suffix.OdsApi.TestSdk</title>").replace("<id>EdFi$suffix.OdsApi.Sdk</id>","<id>EdFi$suffix.OdsApi.TestSdk</id>").replace("<title>EdFi$suffix.OdsApi.Sdk</title>","<title>EdFi$suffix.OdsApi.TestSdk</title>")
             } | Set-Content -Path $nuspecFile
 
             $script:result += Invoke-Task "Pack-TestSdk" { Invoke-Pack-ApiSdk $buildConfiguration $teamCityParameters $version }

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -47,7 +47,7 @@ function Invoke-SdkGen {
     $teamCityParameters = Get-TeamCityParameters
     $envBuildConfiguration = $Env:CONFIGURATION;
     $buildConfiguration = if($null -ne $envBuildConfiguration) { $envBuildConfiguration} else { Get-ValueOrDefault $teamCityParameters['msbuild.buildConfiguration'] 'Debug'}
-    $version = if($null -ne $packageVersion){ $packageVersion } else { (Get-ValueOrDefault $teamCityParameters['version'] '0.0.0') }
+    $version = if($packageVersion){ $packageVersion } else { (Get-ValueOrDefault $teamCityParameters['version'] '0.0.0') }
     
     $elapsed = Use-StopWatch {
         if($generateApiSdkPackage) {

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -23,6 +23,7 @@ param(
     [string] $apiUrl = "http://localhost:8765",
     [string] $environmentFilePath = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath "modules")).Path,
     [Boolean] $generateSdkPackages = $false,
+    [Boolean] $generateTestSdkPackage = $false,
     [string] $packageVersion
 )
 

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -22,7 +22,7 @@ param(
     [string] $configurationFile = $(Get-RepositoryResolvedPath "logistics/scripts/smokeTestHarnessConfiguration.json"),
     [string] $apiUrl = "http://localhost:8765",
     [string] $environmentFilePath = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath "modules")).Path,
-    [Boolean] $generateSdkPackages = $false,
+    [Boolean] $generateApiSdkPackage = $false,
     [Boolean] $generateTestSdkPackage = $false,
     [string] $packageVersion
 )
@@ -62,7 +62,7 @@ function Invoke-SdkGen {
             $script:result += Invoke-Task -name "Stop-TestHarness" -task { Stop-TestHarness }
         }
 
-        if($generateSdkPackages){
+        if($generateApiSdkPackage){
             $sdkSolutionFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln")
             $script:result += Invoke-Task "Restore-ApiSdk-Packages" { Invoke-Restore-ApiSdk-Packages $sdkSolutionFile }
             $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal" $sdkSolutionFile }


### PR DESCRIPTION
This resolved the reported issue since what was happening was the testsdk and apisdk were not being generated correctly 
 in the right builds, so the testsdk that was generated was just the renamed apisdk that did not contain all the necessary resources in the contained dll. The approach to fix this was to introduce two new parameters for handling the package generation, since we need to be able to generate one or the other, or both. These two new parameters control the logic flow that would allow you to generate them in that same combination.

The new parameters referenced in this PR have been added to the initdev template build [here](https://intedfitools1.msdf.org/admin/editBuildParams.html?id=template:OdsPlatform_OdsApiInitDevUnitTestPackageTemplate) , with both set to false, matching the previous parameter that was also set to false. This template is used for initdev unit test, initdev integration test, and initdev postgresql. On the [TestSdk](https://intedfitools1.msdf.org/admin/editBuildParams.html?id=buildType:OdsPlatform_OdsApi_Packages_EdFiOdsApiTestSdk) build, the parameters were also aded and only generating the TestSdk is set to true. The ApiSdk build was not modified since it does not use the initdev script to build its package.

![image](https://user-images.githubusercontent.com/1013553/187284263-0b08dda3-251e-4e43-91aa-72319a1bb6a0.png)

Once this PR is merged the parameter `odsapi.build.generateSdkPackages` will be removed from all builds configurations since it will no longer exist.
