### PR TITLE
[ODS-5372] Support PS 7.2 and Unix - Script group 3

### DIFF
--- a/DatabaseTemplate/Modules/create-database-bacpac.psm1
+++ b/DatabaseTemplate/Modules/create-database-bacpac.psm1
@@ -5,6 +5,8 @@
 
 $ErrorActionPreference = "Stop"
 
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/cross-platform.psm1')
+
 function Export-BacPac {
         <#
     .SYNOPSIS
@@ -56,14 +58,8 @@ function Export-BacPac {
         [ValidateNotNullOrEmpty()]
         [string] $server = "."
     )
-
-    if(Get-IsWindows){
-        $executableName = "sqlpackage.exe"
-    }else {
-        $executableName = "sqlpackage"
-    }
     
-    $executable = Join-Path $sqlPackagePath $executableName
+    $executable = Join-Path $sqlPackagePath "sqlpackage$(GetExeExtension)"
     
     if (-not (Test-Path $executable)) {
         throw [System.IO.FileNotFoundException] "$executable not found."

--- a/DatabaseTemplate/Modules/get-populated-from-nuget.ps1
+++ b/DatabaseTemplate/Modules/get-populated-from-nuget.ps1
@@ -73,7 +73,7 @@ if ($package) {
     $packageFolder = "$global:templateFolder/$($package.PackageFilename -replace '.nupkg','')"
 
     Copy-Item -Force -Path "$global:templateFolder/$($package.PackageFilename)" -Destination $zipFilePath
-    if (Test-Path $zipFilePath) { Microsoft.PowerShell.Archive/Expand-Archive -Force -Path $zipFilePath -DestinationPath $packageFolder }
+    if (Test-Path $zipFilePath) { Expand-Archive -Force -Path $zipFilePath -DestinationPath $packageFolder }
 
     if (Test-Path $packageFolder) {
         if (Test-Path $global:templateDatabaseFolder) { Remove-Item -Force -Recurse -Path $global:templateDatabaseFolder | Out-Null }

--- a/DatabaseTemplate/Modules/get-populated-from-nuget.ps1
+++ b/DatabaseTemplate/Modules/get-populated-from-nuget.ps1
@@ -24,7 +24,7 @@
         packageSource  = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     }
 
-    & "$PSScriptRoot\..\Modules\get-populated-from-nuget.ps1" @params
+    & "$PSScriptRoot/../Modules/get-populated-from-nuget.ps1" @params
 #>
 
 param (
@@ -39,8 +39,8 @@ param (
     [string] $packageSource
 )
 
-& "$PSScriptRoot\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate\Modules\database-template-source.psm1")
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/database-template-source.psm1")
 
 # Ensure we have Tls12 support
 if (-not [Net.ServicePointManager]::SecurityProtocol.HasFlag([Net.SecurityProtocolType]::Tls12))
@@ -69,23 +69,23 @@ $package = (Save-Package @savePackageArgs)
 if ($package) {
     Write-Host "Found populated template nuget package: $($package.Name) v$($package.Version)"
 
-    $zipFilePath = "$global:templateFolder\$($package.PackageFilename -replace '.nupkg', '.zip')"
-    $packageFolder = "$global:templateFolder\$($package.PackageFilename -replace '.nupkg','')"
+    $zipFilePath = "$global:templateFolder/$($package.PackageFilename -replace '.nupkg', '.zip')"
+    $packageFolder = "$global:templateFolder/$($package.PackageFilename -replace '.nupkg','')"
 
-    Copy-Item -Force -Path "$global:templateFolder\$($package.PackageFilename)" -Destination $zipFilePath
-    if (Test-Path $zipFilePath) { Microsoft.PowerShell.Archive\Expand-Archive -Force -Path $zipFilePath -DestinationPath $packageFolder }
+    Copy-Item -Force -Path "$global:templateFolder/$($package.PackageFilename)" -Destination $zipFilePath
+    if (Test-Path $zipFilePath) { Microsoft.PowerShell.Archive/Expand-Archive -Force -Path $zipFilePath -DestinationPath $packageFolder }
 
     if (Test-Path $packageFolder) {
         if (Test-Path $global:templateDatabaseFolder) { Remove-Item -Force -Recurse -Path $global:templateDatabaseFolder | Out-Null }
         New-Item -Path $global:templateDatabaseFolder -ItemType 'Directory' | Out-Null
 
         $backupFilePath = Get-TemplateBackupPath $packageFolder
-        $backupFileDestinationPath = "$global:templateDatabaseFolder\$($package.Name).$($package.Version).bak"
+        $backupFileDestinationPath = "$global:templateDatabaseFolder/$($package.Name).$($package.Version).bak"
         if (($null -ne $backupFilePath) -and (Test-Path $backupFilePath)) {
             Copy-Item -Path $backupFilePath -Destination $backupFileDestinationPath
         }
         else {
-            Copy-Item -Path "$packageFolder\*" -Destination $global:templateDatabaseFolder
+            Copy-Item -Path "$packageFolder/*" -Destination $global:templateDatabaseFolder
         }
         if (Test-Path $backupFileDestinationPath) { Write-Host "Successfully added $(Split-Path $backupFileDestinationPath -Leaf) to populated template source folder" }
     }

--- a/DatabaseTemplate/Modules/get-populated-from-web.ps1
+++ b/DatabaseTemplate/Modules/get-populated-from-web.ps1
@@ -3,10 +3,6 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/database-template-source.psm1")
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/cross-platform.psm1')
-
 <#
 .SYNOPSIS
     Downloads a zip archive containing the populated template backup
@@ -27,7 +23,11 @@ param (
     [string] $fileName
 )
 
-if (-not (Get-InstalledModule | Where-Object -Property Name -eq "7Zip4Powershell") -and (Get-IsWindows)) {
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/database-template-source.psm1")
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/cross-platform.psm1')
+
+if (Get-IsWindows -and -not Get-InstalledModule | Where-Object -Property Name -eq "7Zip4Powershell") {
     Install-Module -Force -Scope CurrentUser -Name 7Zip4Powershell
 }
 

--- a/DatabaseTemplate/Modules/get-populated-from-web.ps1
+++ b/DatabaseTemplate/Modules/get-populated-from-web.ps1
@@ -3,6 +3,10 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/database-template-source.psm1")
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/cross-platform.psm1')
+
 <#
 .SYNOPSIS
     Downloads a zip archive containing the populated template backup
@@ -26,9 +30,6 @@ param (
 if (-not (Get-InstalledModule | Where-Object -Property Name -eq "7Zip4Powershell") -and (Get-IsWindows)) {
     Install-Module -Force -Scope CurrentUser -Name 7Zip4Powershell
 }
-
-& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/database-template-source.psm1")
 
 # using WebClient is faster then Invoke-WebRequest but shows no progress
 Write-host "Downloading file from $sourceUrl..."

--- a/DatabaseTemplate/Modules/get-populated-from-web.ps1
+++ b/DatabaseTemplate/Modules/get-populated-from-web.ps1
@@ -27,8 +27,8 @@ if (-not (Get-InstalledModule | Where-Object -Property Name -eq "7Zip4Powershell
     Install-Module -Force -Scope CurrentUser -Name 7Zip4Powershell
 }
 
-& "$PSScriptRoot\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate\Modules\database-template-source.psm1")
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/database-template-source.psm1")
 
 # using WebClient is faster then Invoke-WebRequest but shows no progress
 Write-host "Downloading file from $sourceUrl..."
@@ -40,7 +40,7 @@ Write-host "Download complete."
 if (Test-Path $global:templateDatabaseFolder) { Remove-Item -Force -Recurse -Path $global:templateDatabaseFolder | Out-Null }
 New-Item -Path $global:templateDatabaseFolder -ItemType "Directory" | Out-Null
 
-if (-not (Test-Path "$global:templateFolder\$fileName")) {
+if (-not (Test-Path "$global:templateFolder/$fileName")) {
     Write-Warning "Populated Template source file '$fileName' not found."
     exit 0
 }

--- a/DatabaseTemplate/Modules/get-template-from-web.ps1
+++ b/DatabaseTemplate/Modules/get-template-from-web.ps1
@@ -61,11 +61,18 @@ else {
 Write-Host "Download complete."
 
 if ($isArchiveFile) {
-    if (-not (Get-InstalledModule | Where-Object -Property Name -EQ "7Zip4Powershell")) {
+    if (-not (Get-InstalledModule | Where-Object -Property Name -EQ "7Zip4Powershell") -and (Get-IsWindows)) {
         Install-Module -Force -Scope CurrentUser -Name 7Zip4Powershell
     }
     Write-Host "Extracting $archiveBackupFilePath..."
-    Expand-7Zip -ArchiveFileName $archiveBackupFilePath -TargetPath $global:templateDatabaseFolder
+    if (Get-IsWindows){
+        Expand-7Zip -ArchiveFileName $archiveBackupFilePath -TargetPath $global:templateDatabaseFolder
+    }
+    else {
+        EnsureCommandIsAvailable "7z"
+        $arguments = @("x", $archiveBackupFilePath, "-o$global:templateDatabaseFolder")
+        7z @arguments
+    }
     Write-Host "Extracted to: $global:templateDatabaseFolder" -ForegroundColor Green
 }
 

--- a/DatabaseTemplate/Modules/get-template-from-web.ps1
+++ b/DatabaseTemplate/Modules/get-template-from-web.ps1
@@ -3,6 +3,10 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/database-template-source.psm1")
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/utility/cross-platform.psm1")
+
 <#
 .SYNOPSIS
     Downloads a backup file or zip archive containing the template backup
@@ -31,9 +35,6 @@ if (Test-Path $finalBackupFilePath) {
     Write-Host "Template found, using existing file at $finalBackupFilePath"
     return $finalBackupFilePath
 }
-
-& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/database-template-source.psm1")
 
 # using WebClient is faster then Invoke-WebRequest but shows no progress
 Write-Host "Downloading file from $sourceUrl..."

--- a/DatabaseTemplate/Modules/get-template-from-web.ps1
+++ b/DatabaseTemplate/Modules/get-template-from-web.ps1
@@ -32,8 +32,8 @@ if (Test-Path $finalBackupFilePath) {
     return $finalBackupFilePath
 }
 
-& "$PSScriptRoot\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate\Modules\database-template-source.psm1")
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/database-template-source.psm1")
 
 # using WebClient is faster then Invoke-WebRequest but shows no progress
 Write-Host "Downloading file from $sourceUrl..."

--- a/DatabaseTemplate/Modules/get-template-from-web.ps1
+++ b/DatabaseTemplate/Modules/get-template-from-web.ps1
@@ -3,10 +3,6 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/database-template-source.psm1")
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/utility/cross-platform.psm1")
-
 <#
 .SYNOPSIS
     Downloads a backup file or zip archive containing the template backup
@@ -27,6 +23,11 @@ param (
     [Parameter(Mandatory)]
     [string] $fileName
 )
+
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/database-template-source.psm1")
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/utility/cross-platform.psm1")
+
 $isArchiveFile = $fileName.EndsWith('.zip') -or $fileName.EndsWith('.7z')
 $archiveBackupFilePath = Join-Path $global:templateFolder $fileName
 $finalBackupFilePath = Join-Path $global:templateDatabaseFolder $fileName
@@ -62,7 +63,7 @@ else {
 Write-Host "Download complete."
 
 if ($isArchiveFile) {
-    if (-not (Get-InstalledModule | Where-Object -Property Name -EQ "7Zip4Powershell") -and (Get-IsWindows)) {
+    if (Get-IsWindows -and -not Get-InstalledModule | Where-Object -Property Name -EQ "7Zip4Powershell") {
         Install-Module -Force -Scope CurrentUser -Name 7Zip4Powershell
     }
     Write-Host "Extracting $archiveBackupFilePath..."

--- a/logistics/scripts/modules/TestHarness.psm1
+++ b/logistics/scripts/modules/TestHarness.psm1
@@ -55,7 +55,7 @@ function Add-RandomKeySecret {
 }
 
 function Get-TestHarnessExecutable {
-    $testHarnessExecutableFilter = "$(Get-RepositoryResolvedPath "/Application/$($script:testHarnessName)")/bin/**/$($script:testHarnessName).exe"
+    $testHarnessExecutableFilter = "$(Get-RepositoryResolvedPath "/Application/$($script:testHarnessName)")/bin/**/$($script:testHarnessName)$(GetExeExtension)"
     $testHarnessExecutable = (Get-ChildItem -Recurse -Path $testHarnessExecutableFilter).FullName
 
     return $testHarnessExecutable
@@ -65,7 +65,7 @@ function Get-SdkGenExecutable {
     Param(
         [string] $buildConfiguration = "Debug"
     )
-    $sdkGenExecutableFilter = "$(Get-RepositoryResolvedPath "/Utilities/SdkGen/EdFi.SdkGen.Console/bin/$buildConfiguration/**/EdFi.SdkGen.Console.exe")"
+    $sdkGenExecutableFilter = "$(Get-RepositoryResolvedPath "/Utilities/SdkGen/EdFi.SdkGen.Console/bin/$buildConfiguration/**/EdFi.SdkGen.Console$(GetExeExtension)")"
     $sdkGenExecutable = (Get-ChildItem -Recurse -Path $sdkGenExecutableFilter).FullName
 
     return $sdkGenExecutable

--- a/logistics/scripts/modules/TestHarness.psm1
+++ b/logistics/scripts/modules/TestHarness.psm1
@@ -5,6 +5,7 @@
 
 & "$PSScriptRoot/../../../logistics/scripts/modules/load-path-resolver.ps1"
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/hashtable.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/cross-platform.psm1')
 
 $script:testHarnessFolder = (Get-RepositoryResolvedPath "Application/EdFi.Ods.Api.IntegrationTestHarness")
 $script:testHarnessName = (Get-Item $script:testHarnessFolder).Name
@@ -131,6 +132,7 @@ function Start-TestHarness {
         }
         catch {
             Write-Host "Waiting for TestHarness startup at $apiUrl..."
+            Start-Sleep -s 1
         }
     }
 

--- a/logistics/scripts/modules/TestHarness.psm1
+++ b/logistics/scripts/modules/TestHarness.psm1
@@ -3,10 +3,10 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-& "$PSScriptRoot\..\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\utility\hashtable.psm1')
+& "$PSScriptRoot/../../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/hashtable.psm1')
 
-$script:testHarnessFolder = (Get-RepositoryResolvedPath "Application\EdFi.Ods.Api.IntegrationTestHarness")
+$script:testHarnessFolder = (Get-RepositoryResolvedPath "Application/EdFi.Ods.Api.IntegrationTestHarness")
 $script:testHarnessName = (Get-Item $script:testHarnessFolder).Name
 
 function Add-RandomKeySecret {
@@ -55,7 +55,7 @@ function Add-RandomKeySecret {
 }
 
 function Get-TestHarnessExecutable {
-    $testHarnessExecutableFilter = "$(Get-RepositoryResolvedPath "\Application\$($script:testHarnessName)")\bin\**\$($script:testHarnessName).exe"
+    $testHarnessExecutableFilter = "$(Get-RepositoryResolvedPath "/Application/$($script:testHarnessName)")/bin/**/$($script:testHarnessName).exe"
     $testHarnessExecutable = (Get-ChildItem -Recurse -Path $testHarnessExecutableFilter).FullName
 
     return $testHarnessExecutable
@@ -65,7 +65,7 @@ function Get-SdkGenExecutable {
     Param(
         [string] $buildConfiguration = "Debug"
     )
-    $sdkGenExecutableFilter = "$(Get-RepositoryResolvedPath "\Utilities\SdkGen\EdFi.SdkGen.Console\bin\$buildConfiguration\**\EdFi.SdkGen.Console.exe")"
+    $sdkGenExecutableFilter = "$(Get-RepositoryResolvedPath "/Utilities/SdkGen/EdFi.SdkGen.Console/bin/$buildConfiguration/**/EdFi.SdkGen.Console.exe")"
     $sdkGenExecutable = (Get-ChildItem -Recurse -Path $sdkGenExecutableFilter).FullName
 
     return $sdkGenExecutable

--- a/logistics/scripts/modules/database/database-management.psm1
+++ b/logistics/scripts/modules/database/database-management.psm1
@@ -3,8 +3,8 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-& "$PSScriptRoot/../load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/database/database-utility.psm1')
+& "$PSScriptRoot\..\load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\database\database-utility.psm1')
 
 function Test-SqlServerModuleInstalled { $null -ne (Get-InstalledModule | where -Property Name -eq SqlServer) }
 

--- a/logistics/scripts/modules/database/database-management.psm1
+++ b/logistics/scripts/modules/database/database-management.psm1
@@ -3,8 +3,8 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-& "$PSScriptRoot\..\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\database\database-utility.psm1')
+& "$PSScriptRoot/../load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/database/database-utility.psm1')
 
 function Test-SqlServerModuleInstalled { $null -ne (Get-InstalledModule | where -Property Name -eq SqlServer) }
 

--- a/logistics/scripts/modules/database/postgres-database-management.psm1
+++ b/logistics/scripts/modules/database/postgres-database-management.psm1
@@ -20,7 +20,7 @@ $script:packageVersion = "13.7.1"
 function Test-PostgreSQLBinariesInstalled {
     if (!(Get-IsWindows)) {
 
-        return IsCommandAvailable "psql" "-V"
+        return IsCommandAvailable "psql"
     }
 
     $packagePath = "$script:toolsPath/$script:packageName.$script:packageVersion"

--- a/logistics/scripts/modules/database/postgres-database-management.psm1
+++ b/logistics/scripts/modules/database/postgres-database-management.psm1
@@ -19,13 +19,8 @@ $script:packageVersion = "13.7.1"
 
 function Test-PostgreSQLBinariesInstalled {
     if (!(Get-IsWindows)) {
-        try {
-            (psql -V | Out-Null)
-            return $true
-        }
-        catch {
-            return $false
-        }
+
+        return IsCommandAvailable "psql" "-V"
     }
 
     $packagePath = "$script:toolsPath/$script:packageName.$script:packageVersion"

--- a/logistics/scripts/modules/packaging/create-package.psm1
+++ b/logistics/scripts/modules/packaging/create-package.psm1
@@ -8,6 +8,7 @@
 $ErrorActionPreference = "Stop"
 
 Import-Module -Force -Scope Global "$PSScriptRoot/nuget-helper.psm1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/utility/cross-platform.psm1")
 
 function Invoke-CreatePackage {
     <#

--- a/logistics/scripts/modules/packaging/nuget-helper.psm1
+++ b/logistics/scripts/modules/packaging/nuget-helper.psm1
@@ -29,12 +29,7 @@ function Install-NuGetCli {
     )
 
     if (!(Get-IsWindows)) {
-        try {
-            ( mono -V  | Out-Null )
-        }
-        catch {
-            throw "ERROR:  Mono is not installed on this Unix-like system."
-        }
+        EnsureCommandIsAvailable "mono" "-V"
     }
 
     if (-not $(Test-Path $ToolsPath)) {

--- a/logistics/scripts/modules/packaging/nuget-helper.psm1
+++ b/logistics/scripts/modules/packaging/nuget-helper.psm1
@@ -29,7 +29,7 @@ function Install-NuGetCli {
     )
 
     if (!(Get-IsWindows)) {
-        EnsureCommandIsAvailable "mono" "-V"
+        EnsureCommandIsAvailable "mono"
     }
 
     if (-not $(Test-Path $ToolsPath)) {

--- a/logistics/scripts/modules/packaging/packaging.psm1
+++ b/logistics/scripts/modules/packaging/packaging.psm1
@@ -84,7 +84,7 @@ function Add-FileToNuspec {
 
     $filesElem = $xml.GetElementsByTagName('files')[0]
     foreach ($pair in $sourceTargetPair) {
-        $resolvedTarget = $pair.target -replace '/', '\' -replace '\\\\', '\'
+        $resolvedTarget = $pair.target -replace '/', [IO.Path]::DirectorySeparatorChar -replace '\\\\', '\'
         foreach ($source in $pair.source) {
             if ((Get-Item $source).gettype() -match "DirectoryInfo") {
                 continue
@@ -125,10 +125,10 @@ function Add-RepositoryFileToNuspec {
         foreach ($repoRoot in Get-RepositoryRoot) {
             $repoName = Split-Path -leaf $repoRoot
 
-            $escRegex = [Regex]::Escape("$($repoRoot.tolower())\")
+            $escRegex = [Regex]::Escape("$($repoRoot.tolower())$([IO.Path]::DirectorySeparatorChar)")
             if ($fullname -match "^$escRegex") {
                 $relPath = $fullname -replace $escRegex, ''
-                $sourceTargetPair += @(@{ source = $fullname; target = "$repoName\$relPath" })
+                $sourceTargetPair += @(@{ source = $fullname; target = "$repoName$([IO.Path]::DirectorySeparatorChar)$relPath" })
                 $foundRepoRoot = $true
                 break
             }

--- a/logistics/scripts/modules/packaging/packaging.psm1
+++ b/logistics/scripts/modules/packaging/packaging.psm1
@@ -3,7 +3,7 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-& "$PSScriptRoot\..\..\..\..\logistics\scripts\modules\load-path-resolver.ps1"
+& "$PSScriptRoot/../../../../logistics/scripts/modules/load-path-resolver.ps1"
 
 function New-Nuspec {
     param(

--- a/logistics/scripts/modules/packaging/restore-packages.psm1
+++ b/logistics/scripts/modules/packaging/restore-packages.psm1
@@ -4,6 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 Import-Module -Force -Scope Global "$PSScriptRoot/nuget-helper.psm1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/utility/cross-platform.psm1")
 
 function Restore-Packages {
     <#

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -231,9 +231,9 @@ function Invoke-DbDeploy {
         Database = "ODS"
         ConnectionString = "server=localhost;database=EdFi_Ods;integrated security=sspi"
         FilePaths = @(
-            "Ed-Fi-Ods\", "Ed-Fi-ODS\Application\EdFi.Ods.Standard",
-            "C:\Source\3.x\Ed-Fi-Ods-Implementation\Application\EdFi.Ods.Extensions.GrandBend\SupportingArtifacts\Database",
-            "C:\Source\3.x\Ed-Fi-Ods-Implementation\Application\EdFi.Ods.Extensions.Sample\SupportingArtifacts\Database"
+            "Ed-Fi-Ods/", "Ed-Fi-ODS/Application/EdFi.Ods.Standard",
+            "C:/Source/3.x/Ed-Fi-Ods-Implementation/Application/EdFi.Ods.Extensions.GrandBend/SupportingArtifacts/Database",
+            "C:/Source/3.x/Ed-Fi-Ods-Implementation/Application/EdFi.Ods.Extensions.Sample/SupportingArtifacts/Database"
         )
         Features = @("Changes")
     }

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -6,8 +6,8 @@
 #requires -version 5
 $ErrorActionPreference = 'Stop'
 
-& "$PSScriptRoot\..\..\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\utility\cross-platform.psm1")
+& "$PSScriptRoot/../../../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/utility/cross-platform.psm1")
 
 function Get-ToolsPath {
     if (-not [string]::IsNullOrWhiteSpace($env:toolsPath)) { return $env:toolsPath }

--- a/logistics/scripts/modules/utility/cross-platform.psm1
+++ b/logistics/scripts/modules/utility/cross-platform.psm1
@@ -1,3 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+function GetExeExtension() {
+    return @(If (Get-IsWindows) { ".exe" } Else { "" })
+}
+
 function IsCommandAvailable {
     param (
         [String]
@@ -53,7 +62,6 @@ function Get-IsWindows {
     return $IsWindows
 }
 
-
 function Get-DotnetRuntimes {
 
     try {
@@ -85,4 +93,5 @@ Export-ModuleMember -Function `
     Get-IsWindows,
     Get-DotnetRuntimes,
     IsCommandAvailable,
-    EnsureCommandIsAvailable
+    EnsureCommandIsAvailable, 
+    GetExeExtension

--- a/logistics/scripts/modules/utility/cross-platform.psm1
+++ b/logistics/scripts/modules/utility/cross-platform.psm1
@@ -1,3 +1,37 @@
+function IsCommandAvailable {
+    param (
+        [String]
+        [Parameter(Mandatory=$true)]
+        $Command,
+
+        [string[]]
+        $Arguments
+    )
+
+    try {
+        & $Command @Arguments | Out-Null
+        return $true
+    }
+    catch {
+        return $false 
+    }
+}
+
+function EnsureCommandIsAvailable {
+    param (
+        [String]
+        [Parameter(Mandatory=$true)]
+        $Command,
+
+        [string[]]
+        $Arguments
+    )
+
+    if (!(IsCommandAvailable $Command $Arguments)) {
+        throw "The next command is required by the script but it is not installed: $Command"
+    }
+}
+
 function Get-IsWindows {
     <#
     .SYNOPSIS
@@ -12,8 +46,8 @@ function Get-IsWindows {
     if ($null -eq $IsWindows) {
         # This section will only trigger when the automatic $IsWindows variable is not detected.
         # Every version of PS released on Linux contains this variable so it will always exist.
-        # $IsWindows does not exist pre PS 6, so this will create it in that case.
-        $IsWindows = $true
+        # $IsWindows does not exist pre PS 6.
+        return $true
     }
 
     return $IsWindows
@@ -46,4 +80,9 @@ function Get-DotnetRuntimes {
     }
     return $runtimeArray
 }
-Export-ModuleMember -Function "Get-IsWindows","Get-DotnetRuntimes"
+
+Export-ModuleMember -Function `
+    Get-IsWindows,
+    Get-DotnetRuntimes,
+    IsCommandAvailable,
+    EnsureCommandIsAvailable

--- a/logistics/scripts/modules/utility/cross-platform.psm1
+++ b/logistics/scripts/modules/utility/cross-platform.psm1
@@ -11,14 +11,11 @@ function IsCommandAvailable {
     param (
         [String]
         [Parameter(Mandatory=$true)]
-        $Command,
-
-        [string[]]
-        $Arguments
+        $Command
     )
 
     try {
-        & $Command @Arguments | Out-Null
+        Get-Command $Command -ErrorAction Stop | Out-Null
         return $true
     }
     catch {
@@ -30,13 +27,10 @@ function EnsureCommandIsAvailable {
     param (
         [String]
         [Parameter(Mandatory=$true)]
-        $Command,
-
-        [string[]]
-        $Arguments
+        $Command
     )
 
-    if (!(IsCommandAvailable $Command $Arguments)) {
+    if (!(IsCommandAvailable $Command)) {
         throw "The next command is required by the script but it is not installed: $Command"
     }
 }

--- a/logistics/scripts/modules/utility/xml-validation.psm1
+++ b/logistics/scripts/modules/utility/xml-validation.psm1
@@ -44,15 +44,15 @@ function Invoke-XmlValidation {
         Validates xml files using the schema location defined within an xml file.
 
     .PARAMETER source
-        An absolute path to the folder to load samples from, for example: C:\MySampleXmlData\.
-        Also supports specific version folders of the Data Standard repository, for example: C:\Ed-Fi-Standard\v3.0\ or C:\Ed-Fi-Standard\v2.0\
+        An absolute path to the folder to load samples from, for example: C:/MySampleXmlData/.
+        Also supports specific version folders of the Data Standard repository, for example: C:/Ed-Fi-Standard/v3.0/ or C:/Ed-Fi-Standard/v2.0/
     .INPUTS
         [string] Source Directory
         [string] Filter
     .OUTPUTS
         None.
     .EXAMPLE
-        PS> Validate-Xml -source "C:\edfi\Ed-Fi-Standard\v3.1\Samples\Sample XML\
+        PS> Validate-Xml -source "C:/edfi/Ed-Fi-Standard/v3.1/Samples/Sample XML/
     #>
     param(
         # The source directory where the files are located.

--- a/logistics/scripts/modules/utility/xml-validation.psm1
+++ b/logistics/scripts/modules/utility/xml-validation.psm1
@@ -3,8 +3,8 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-& "$PSScriptRoot\..\..\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\tasks\TaskHelper.psm1')
+& "$PSScriptRoot/../../../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/tasks/TaskHelper.psm1')
 
 function Get-XmlRoot {
     param(

--- a/logistics/scripts/run-tests.ps1
+++ b/logistics/scripts/run-tests.ps1
@@ -5,7 +5,11 @@
 
 & "$PSScriptRoot/modules/load-path-resolver.ps1"
 
-$testAssemblies = (Get-ChildItem -recurse -File $((Get-RepositoryRoot "Ed-Fi-ODS") + "/*Tests.dll") | Where-Object { $_.FullName -match "\\bin\\?" -and $_.FullName -notmatch "\\net48\\?" -and $_.fullName -notmatch "ApprovalTests.dll" -and $_.fullName -notmatch "\\ref\\?" })
+$testAssemblies = (Get-ChildItem -recurse -File $((Get-RepositoryRoot "Ed-Fi-ODS") + "/*Tests.dll") | `
+        Where-Object { $_.FullName -match "$([IO.Path]::DirectorySeparatorChar)bin$([IO.Path]::DirectorySeparatorChar)?" `
+            -and $_.FullName -notmatch "$([IO.Path]::DirectorySeparatorChar)net48$([IO.Path]::DirectorySeparatorChar)?" `
+            -and $_.fullName -notmatch "ApprovalTests.dll" `
+            -and $_.fullName -notmatch "$([IO.Path]::DirectorySeparatorChar)ref$([IO.Path]::DirectorySeparatorChar)?" })
 $reports = (Get-RepositoryRoot "Ed-Fi-ODS-Implementation") + "/reports/"
 
 if (Test-Path $reports) {

--- a/logistics/scripts/run-tests.ps1
+++ b/logistics/scripts/run-tests.ps1
@@ -4,6 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 & "$PSScriptRoot/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/utility/cross-platform.psm1")
 
 $directorySeparatorChar = [IO.Path]::DirectorySeparatorChar
 if (Get-IsWindows) {

--- a/logistics/scripts/run-tests.ps1
+++ b/logistics/scripts/run-tests.ps1
@@ -5,11 +5,17 @@
 
 & "$PSScriptRoot/modules/load-path-resolver.ps1"
 
+$directorySeparatorChar = [IO.Path]::DirectorySeparatorChar
+if (Get-IsWindows) {
+    # In Windows, double backslashes are needed for the filters to work
+    $directorySeparatorChar += $directorySeparatorChar
+}
+
 $testAssemblies = (Get-ChildItem -recurse -File $((Get-RepositoryRoot "Ed-Fi-ODS") + "/*Tests.dll") | `
-        Where-Object { $_.FullName -match "$([IO.Path]::DirectorySeparatorChar)bin$([IO.Path]::DirectorySeparatorChar)?" `
-            -and $_.FullName -notmatch "$([IO.Path]::DirectorySeparatorChar)net48$([IO.Path]::DirectorySeparatorChar)?" `
+        Where-Object { $_.FullName -match "$($directorySeparatorChar)bin$($directorySeparatorChar)?" `
+            -and $_.FullName -notmatch "$($directorySeparatorChar)net48$($directorySeparatorChar)?" `
             -and $_.fullName -notmatch "ApprovalTests.dll" `
-            -and $_.fullName -notmatch "$([IO.Path]::DirectorySeparatorChar)ref$([IO.Path]::DirectorySeparatorChar)?" })
+            -and $_.fullName -notmatch "$($directorySeparatorChar)ref$($directorySeparatorChar)?" })
 $reports = (Get-RepositoryRoot "Ed-Fi-ODS-Implementation") + "/reports/"
 
 if (Test-Path $reports) {

--- a/logistics/scripts/run-tests.ps1
+++ b/logistics/scripts/run-tests.ps1
@@ -3,10 +3,10 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-& "$PSScriptRoot\modules\load-path-resolver.ps1"
+& "$PSScriptRoot/modules/load-path-resolver.ps1"
 
-$testAssemblies = (Get-ChildItem -recurse -File $((Get-RepositoryRoot "ed-fi-ods") + "\*Tests.dll") | Where-Object { $_.FullName -match "\\bin\\?" -and $_.FullName -notmatch "\\net48\\?" -and $_.fullName -notmatch "ApprovalTests.dll" -and $_.fullName -notmatch "\\ref\\?" })
-$reports = (Get-RepositoryRoot "ed-fi-ods-implementation") + "\reports\"
+$testAssemblies = (Get-ChildItem -recurse -File $((Get-RepositoryRoot "Ed-Fi-ODS") + "/*Tests.dll") | Where-Object { $_.FullName -match "\\bin\\?" -and $_.FullName -notmatch "\\net48\\?" -and $_.fullName -notmatch "ApprovalTests.dll" -and $_.fullName -notmatch "\\ref\\?" })
+$reports = (Get-RepositoryRoot "Ed-Fi-ODS-Implementation") + "/reports/"
 
 if (Test-Path $reports) {
     Remove-Item -Path $reports -Force -Recurse


### PR DESCRIPTION
Note that no changes were made to `database-management.psm1` since SQL Server for Linux is not going to be supported; PostgreSQL is the only supported engine in Linux.
To test `get-populated-from-nuget.ps1`, you have to use a v2 Nuget feed (v3 isn't supported by Save-Package), use: https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v2/