### PR TITLE
ODS-5579 - Update initdev builds for 6.1

### DIFF
--- a/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -24,7 +24,7 @@ env:
   BUILD_INCREMENTER: "1"
   CONFIGURATION: "Release"
   VERSION_MAJOR: "6"
-  VERSION_MINOR: "0"
+  VERSION_MINOR: "1"
   CURRENT_BRANCH: ${{ GITHUB.HEAD_REF }}
   ODS_CURRENT_BRANCH: ${{ github.event.client_payload.ref }}
   EDFI_SUITE_NUMBER: "Suite3"

--- a/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
+++ b/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
@@ -22,7 +22,7 @@ env:
   BUILD_INCREMENTER: "1"
   CONFIGURATION: "Release"
   VERSION_MAJOR: "6"
-  VERSION_MINOR: "0"
+  VERSION_MINOR: "1"
   CURRENT_BRANCH: ${{ GITHUB.HEAD_REF }}
   ODS_CURRENT_BRANCH: ${{ github.event.client_payload.ref }}
   EDFI_SUITE_NUMBER: "Suite3"

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -22,7 +22,7 @@ env:
   BUILD_INCREMENTER: "1"
   CONFIGURATION: "Release"
   VERSION_MAJOR: "6"
-  VERSION_MINOR: "0"
+  VERSION_MINOR: "1"
   CURRENT_BRANCH: ${{ GITHUB.HEAD_REF }}
   ODS_CURRENT_BRANCH: ${{ github.event.client_payload.ref }}
   EDFI_SUITE_NUMBER: "Suite3"

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -24,7 +24,7 @@ env:
   BUILD_INCREMENTER: "1"
   CONFIGURATION: "Release"
   VERSION_MAJOR: "6"
-  VERSION_MINOR: "0"
+  VERSION_MINOR: "1"
   CURRENT_BRANCH: ${{ GITHUB.HEAD_REF }}
   ODS_CURRENT_BRANCH: ${{ github.event.client_payload.ref }}
   EDFI_SUITE_NUMBER: "Suite3"


### PR DESCRIPTION
In previous update to move everything to 6.1 we missed changing the minor version. Now it is updated.