### PR TITLE
ODS-5581 - Update step for checking out ods repo

### DIFF
--- a/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -25,8 +25,9 @@ env:
   CONFIGURATION: "Release"
   VERSION_MAJOR: "6"
   VERSION_MINOR: "1"
-  CURRENT_BRANCH: ${{ GITHUB.HEAD_REF }}
-  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.branch }}
+  HEAD_REF:  ${{ GITHUB.HEAD_REF }}
+  REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
 
 jobs:
@@ -50,35 +51,17 @@ jobs:
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-            $patternName = 'refs/heads/' +  '${{ env.CURRENT_BRANCH }}'
-            $is_pull_request_branch = 'False'
-            $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
-            if ($is_pull_request_branch -eq $true) {
-              git fetch origin ${{ env.CURRENT_BRANCH }}
-              git checkout ${{ env.CURRENT_BRANCH }}
-            }
+           .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "."
     - name: Checkout Ed-Fi-ODS
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
           path: Ed-Fi-ODS/
     - name: Is pull request branch exists in Ed-Fi-ODS
-      working-directory: ./Ed-Fi-ODS/
+      working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-           $patternName = 'refs/heads/' +  '${{ env.CURRENT_BRANCH }}'
-           $is_pull_request_branch = 'False'
-           $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
-           $odsBranch = '${{ env.ODS_CURRENT_BRANCH }}'
-           if($odsBranch -ne ''){
-              git fetch origin $odsBranch
-              git checkout $odsBranch
-           } else {
-              if ($is_pull_request_branch -eq $true) {
-                git fetch origin ${{ env.CURRENT_BRANCH }}
-                git checkout ${{ env.CURRENT_BRANCH }}
-              }
-           }
+           .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
     - name: Start PostgreSQL
       run: |
         $pgService = Get-Service -Name postgresql*

--- a/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -26,7 +26,7 @@ env:
   VERSION_MAJOR: "6"
   VERSION_MINOR: "1"
   CURRENT_BRANCH: ${{ GITHUB.HEAD_REF }}
-  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.ref }}
+  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
 
 jobs:

--- a/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
+++ b/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
@@ -24,7 +24,7 @@ env:
   VERSION_MAJOR: "6"
   VERSION_MINOR: "1"
   CURRENT_BRANCH: ${{ GITHUB.HEAD_REF }}
-  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.ref }}
+  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
 
 jobs:

--- a/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
+++ b/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
@@ -23,8 +23,9 @@ env:
   CONFIGURATION: "Release"
   VERSION_MAJOR: "6"
   VERSION_MINOR: "1"
-  CURRENT_BRANCH: ${{ GITHUB.HEAD_REF }}
-  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.branch }}
+  HEAD_REF:  ${{ GITHUB.HEAD_REF }}
+  REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
 
 jobs:
@@ -48,35 +49,17 @@ jobs:
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-            $patternName = 'refs/heads/' +  '${{ env.CURRENT_BRANCH }}'
-            $is_pull_request_branch = 'False'
-            $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
-            if ($is_pull_request_branch -eq $true) {
-              git fetch origin ${{ env.CURRENT_BRANCH }}
-              git checkout ${{ env.CURRENT_BRANCH }}
-            }
+           .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "."
     - name: Checkout Ed-Fi-ODS
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
           path: Ed-Fi-ODS/
     - name: Is pull request branch exists in Ed-Fi-ODS
-      working-directory: ./Ed-Fi-ODS/
+      working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-           $patternName = 'refs/heads/' +  '${{ env.CURRENT_BRANCH }}'
-           $is_pull_request_branch = 'False'
-           $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
-           $odsBranch = '${{ env.ODS_CURRENT_BRANCH }}'
-           if($odsBranch -ne ''){
-              git fetch origin $odsBranch
-              git checkout $odsBranch
-           } else {
-              if ($is_pull_request_branch -eq $true) {
-                git fetch origin ${{ env.CURRENT_BRANCH }}
-                git checkout ${{ env.CURRENT_BRANCH }}
-              }
-           }
+           .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
     - name: Start PostgreSQL
       run: |
         $pgService = Get-Service -Name postgresql*

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -25,7 +25,7 @@ env:
   VERSION_MINOR: "1"
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
-  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.ref }}
+  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
 
 jobs:

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -49,13 +49,33 @@ jobs:
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-            $patternName = 'refs/heads/' +  '${{ env.CURRENT_BRANCH }}'
-            Write-Host "Pattern Name is " $patternName -fore GREEN
-            $is_pull_request_branch = 'False'
-            $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
-            if ($is_pull_request_branch -eq $true) {
-              git fetch origin ${{ env.CURRENT_BRANCH }}
-              git checkout ${{ env.CURRENT_BRANCH }}
+            $odsBranch = '${{ env.ODS_CURRENT_BRANCH }}'
+            Write-Host "OdsBranch: $odsBranch"
+            if($odsBranch -ne ''){
+              $patternName = "refs/heads/$odsBranch"
+              $does_corresponding_branch_exist = $false
+              $does_corresponding_branch_exist = git ls-remote --heads origin $odsBranch | Select-String -Pattern $patternName -SimpleMatch -Quiet
+              if ($does_corresponding_branch_exist -eq $true) {
+                Write-Host "Corresponding branch for $odsBranch exists in Implementation repo, so checking it out"
+                git fetch origin odsBranch
+                git checkout odsBranch
+              }
+            } else {
+              Write-Host "ref_name: ${{env.REF_NAME}}"
+              $current_branch = '${{env.REF_NAME}}'
+              if ($current_branch -like "*/merge"){
+                Write-Host "ref_name is PR, so using head_ref: ${{env.HEAD_REF}}"
+                $current_branch = '${{env.HEAD_REF}}'
+              }
+              $patternName = "refs/heads/$current_branch"
+              Write-Host "Pattern Name is " $patternName -fore GREEN
+              $is_pull_request_branch = $false
+              $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
+              if ($is_pull_request_branch -eq $true) {
+                Write-Host "Found Implementation branch with name ${{ env.CURRENT_BRANCH }} so checking it out"
+                git fetch origin ${{ env.CURRENT_BRANCH }}
+                git checkout ${{ env.CURRENT_BRANCH }}
+              }
             }
     - name: Checkout Ed-Fi-ODS
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
@@ -82,7 +102,7 @@ jobs:
               
               Write-Host "Current Branch: $current_branch"
               $patternName = 'refs/heads/' +  $current_branch
-              $branch_exists = 'False'
+              $branch_exists = $false
               $branch_exists = git ls-remote --heads origin $current_branch | Select-String -Pattern $patternName -SimpleMatch -Quiet
               if ($branch_exists -eq $true) {
                 Write-Host "Current branch exists, so setting to $current_branch"

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -64,13 +64,13 @@ jobs:
               }
            } else {
               Write-Host "ref_name: ${{env.REF_NAME}}"
-              $current_branch = ${{env.REF_NAME}}
+              $current_branch = "${{env.REF_NAME}}"
               if ($current_branch -like "*/merge"){
                 Write-Host "ref_name is PR, so using head_ref: ${{env.HEAD_REF}}"
-                $current_branch = ${{env.HEAD_REF}}
+                $current_branch = "${{env.HEAD_REF}}"
               }
               $patternName = "refs/heads/$current_branch"
-              Write-Host "Pattern Name is " $patternName -fore GREEN
+              Write-Host "Pattern Name is $patternName" -fore GREEN
               $branch_exists = $false
               $branch_exists = git ls-remote --heads origin $current_branch | Select-String -Pattern $patternName -SimpleMatch -Quiet
               if ($branch_exists -eq $true) {

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -49,38 +49,7 @@ jobs:
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-           $odsBranch = '${{ env.REPOSITORY_DISPATCH_BRANCH }}'
-           Write-Host "OdsBranch: $odsBranch"
-           if($odsBranch -ne ''){
-              $patternName = "refs/heads/$odsBranch"
-              $does_corresponding_branch_exist = $false
-              $does_corresponding_branch_exist = git ls-remote --heads origin $odsBranch | Select-String -Pattern $patternName -SimpleMatch -Quiet
-              if ($does_corresponding_branch_exist -eq $true) {
-                Write-Host "Corresponding branch for $odsBranch exists in Implementation repo, so checking it out"
-                git fetch origin $odsBranch
-                git checkout $odsBranch
-              } else {
-                WriteHost "Corresponding branch for $odsBranch does not exist in Implementation repo, so not changing branch checked out"
-              }
-           } else {
-              Write-Host "ref_name: ${{env.REF_NAME}}"
-              $current_branch = "${{env.REF_NAME}}"
-              if ($current_branch -like "*/merge"){
-                Write-Host "ref_name is PR, so using head_ref: ${{env.HEAD_REF}}"
-                $current_branch = "${{env.HEAD_REF}}"
-              }
-              $patternName = "refs/heads/$current_branch"
-              Write-Host "Pattern Name is $patternName" -fore GREEN
-              $branch_exists = $false
-              $branch_exists = git ls-remote --heads origin $current_branch | Select-String -Pattern $patternName -SimpleMatch -Quiet
-              if ($branch_exists -eq $true) {
-                Write-Host "Current branch exists, so setting to $current_branch"
-                git fetch origin $current_branch
-                git checkout $current_branch
-              } else {
-                Write-Host "did not match on any results for changing ODS checkout branch"
-              }
-           }
+           .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "."
     - name: Checkout Ed-Fi-ODS
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -57,17 +57,17 @@ jobs:
               $does_corresponding_branch_exist = git ls-remote --heads origin $odsBranch | Select-String -Pattern $patternName -SimpleMatch -Quiet
               if ($does_corresponding_branch_exist -eq $true) {
                 Write-Host "Corresponding branch for $odsBranch exists in Implementation repo, so checking it out"
-                git fetch origin odsBranch
-                git checkout odsBranch
+                git fetch origin $odsBranch
+                git checkout $odsBranch
               } else {
-                WriteHost "Corresponding branch for #odsBranch does not exist in Implementation repo, so not changing branch checked out"
+                WriteHost "Corresponding branch for $odsBranch does not exist in Implementation repo, so not changing branch checked out"
               }
            } else {
               Write-Host "ref_name: ${{env.REF_NAME}}"
-              $current_branch = '${{env.REF_NAME}}'
+              $current_branch = ${{env.REF_NAME}}
               if ($current_branch -like "*/merge"){
                 Write-Host "ref_name is PR, so using head_ref: ${{env.HEAD_REF}}"
-                $current_branch = '${{env.HEAD_REF}}'
+                $current_branch = ${{env.HEAD_REF}}
               }
               $patternName = "refs/heads/$current_branch"
               Write-Host "Pattern Name is " $patternName -fore GREEN
@@ -98,17 +98,17 @@ jobs:
               $does_corresponding_branch_exist = git ls-remote --heads origin $odsBranch | Select-String -Pattern $patternName -SimpleMatch -Quiet
               if ($does_corresponding_branch_exist -eq $true) {
                 Write-Host "Corresponding branch for $odsBranch exists in Implementation repo, so checking it out"
-                git fetch origin odsBranch
-                git checkout odsBranch
+                git fetch origin $odsBranch
+                git checkout $odsBranch
               } else {
-                WriteHost "Corresponding branch for #odsBranch does not exist in Implementation repo, so not changing branch checked out"
+                WriteHost "Corresponding branch for $odsBranch does not exist in Implementation repo, so not changing branch checked out"
               }
            } else {
               Write-Host "ref_name: ${{env.REF_NAME}}"
-              $current_branch = '${{env.REF_NAME}}'
+              $current_branch = ${{env.REF_NAME}}
               if ($current_branch -like "*/merge"){
                 Write-Host "ref_name is PR, so using head_ref: ${{env.HEAD_REF}}"
-                $current_branch = '${{env.HEAD_REF}}'
+                $current_branch = ${{env.HEAD_REF}}
               }
               $patternName = "refs/heads/$current_branch"
               Write-Host "Pattern Name is " $patternName -fore GREEN

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -90,38 +90,7 @@ jobs:
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh
       run: |
-           $odsBranch = '${{ env.REPOSITORY_DISPATCH_BRANCH }}'
-           Write-Host "OdsBranch: $odsBranch"
-           if($odsBranch -ne ''){
-              $patternName = "refs/heads/$odsBranch"
-              $does_corresponding_branch_exist = $false
-              $does_corresponding_branch_exist = git ls-remote --heads origin $odsBranch | Select-String -Pattern $patternName -SimpleMatch -Quiet
-              if ($does_corresponding_branch_exist -eq $true) {
-                Write-Host "Corresponding branch for $odsBranch exists in Implementation repo, so checking it out"
-                git fetch origin $odsBranch
-                git checkout $odsBranch
-              } else {
-                WriteHost "Corresponding branch for $odsBranch does not exist in Implementation repo, so not changing branch checked out"
-              }
-           } else {
-              Write-Host "ref_name: ${{env.REF_NAME}}"
-              $current_branch = ${{env.REF_NAME}}
-              if ($current_branch -like "*/merge"){
-                Write-Host "ref_name is PR, so using head_ref: ${{env.HEAD_REF}}"
-                $current_branch = ${{env.HEAD_REF}}
-              }
-              $patternName = "refs/heads/$current_branch"
-              Write-Host "Pattern Name is " $patternName -fore GREEN
-              $branch_exists = $false
-              $branch_exists = git ls-remote --heads origin $current_branch | Select-String -Pattern $patternName -SimpleMatch -Quiet
-              if ($branch_exists -eq $true) {
-                Write-Host "Current branch exists, so setting to $current_branch"
-                git fetch origin $current_branch
-                git checkout $current_branch
-              } else {
-                Write-Host "did not match on any results for changing ODS checkout branch"
-              }
-           }
+           .\build.githubactions.ps1 CheckoutBranch
     - name: Setup Sql Server Connection String
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -87,10 +87,10 @@ jobs:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
           path: Ed-Fi-ODS/
     - name: Is pull request branch exists in Ed-Fi-ODS
-      working-directory: ./Ed-Fi-ODS/
+      working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-           .\build.githubactions.ps1 CheckoutBranch
+           .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
     - name: Setup Sql Server Connection String
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -23,7 +23,8 @@ env:
   CONFIGURATION: "Release"
   VERSION_MAJOR: "6"
   VERSION_MINOR: "1"
-  CURRENT_BRANCH: ${{ GITHUB.HEAD_REF }}
+  HEAD_REF:  ${{ GITHUB.HEAD_REF }}
+  REF_NAME:  ${{ GITHUB.REF_NAME }}
   ODS_CURRENT_BRANCH: ${{ github.event.client_payload.ref }}
   EDFI_SUITE_NUMBER: "Suite3"
 
@@ -65,20 +66,30 @@ jobs:
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh
       run: |
-           $patternName = 'refs/heads/' +  '${{ env.CURRENT_BRANCH }}'
-           Write-Host "Pattern Name is " $patternName -fore GREEN
-           $is_pull_request_branch = 'False'
-           $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
-           Write-Host "pull request branch is '$($is_pull_request_branch -eq $true)'" -fore GREEN
            $odsBranch = '${{ env.ODS_CURRENT_BRANCH }}'
+           Write-Host "OdsBranch: $odsBranch"
            if($odsBranch -ne ''){
+              Write-Host "Checking out ODS branch of $odsBranch"
               git fetch origin $odsBranch
               git checkout $odsBranch
            } else {
-              if ($is_pull_request_branch -eq $true) {
-                Write-Host "pull request branch " + ${{ env.CURRENT_BRANCH }} + "exists" -fore GREEN
-                git fetch origin ${{ env.CURRENT_BRANCH }}
-                git checkout ${{ env.CURRENT_BRANCH }}
+              Write-Host "ref_name: ${{env.REF_NAME}}"
+              $current_branch = '${{env.REF_NAME}}'
+              if ($current_branch -like "*/merge"){
+                Write-Host "ref_name is PR, so using head_ref: ${{env.HEAD_REF}}"
+                $current_branch = '${{env.HEAD_REF}}'
+              }
+              
+              Write-Host "Current Branch: $current_branch"
+              $patternName = 'refs/heads/' +  $current_branch
+              $branch_exists = 'False'
+              $branch_exists = git ls-remote --heads origin $current_branch | Select-String -Pattern $patternName -SimpleMatch -Quiet
+              if ($branch_exists -eq $true) {
+                Write-Host "Current branch exists, so setting to $current_branch"
+                git fetch origin $current_branch
+                git checkout $current_branch
+              } else {
+                Write-Host "did not match on any results for changing ODS checkout branch"
               }
            }
     - name: Setup Sql Server Connection String

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -25,7 +25,7 @@ env:
   VERSION_MINOR: "1"
   HEAD_REF:  ${{ GITHUB.HEAD_REF }}
   REF_NAME:  ${{ GITHUB.REF_NAME }}
-  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.branch }}
+  REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
 
 jobs:
@@ -49,9 +49,9 @@ jobs:
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-            $odsBranch = '${{ env.ODS_CURRENT_BRANCH }}'
-            Write-Host "OdsBranch: $odsBranch"
-            if($odsBranch -ne ''){
+           $odsBranch = '${{ env.REPOSITORY_DISPATCH_BRANCH }}'
+           Write-Host "OdsBranch: $odsBranch"
+           if($odsBranch -ne ''){
               $patternName = "refs/heads/$odsBranch"
               $does_corresponding_branch_exist = $false
               $does_corresponding_branch_exist = git ls-remote --heads origin $odsBranch | Select-String -Pattern $patternName -SimpleMatch -Quiet
@@ -59,8 +59,10 @@ jobs:
                 Write-Host "Corresponding branch for $odsBranch exists in Implementation repo, so checking it out"
                 git fetch origin odsBranch
                 git checkout odsBranch
+              } else {
+                WriteHost "Corresponding branch for #odsBranch does not exist in Implementation repo, so not changing branch checked out"
               }
-            } else {
+           } else {
               Write-Host "ref_name: ${{env.REF_NAME}}"
               $current_branch = '${{env.REF_NAME}}'
               if ($current_branch -like "*/merge"){
@@ -69,14 +71,16 @@ jobs:
               }
               $patternName = "refs/heads/$current_branch"
               Write-Host "Pattern Name is " $patternName -fore GREEN
-              $is_pull_request_branch = $false
-              $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
-              if ($is_pull_request_branch -eq $true) {
-                Write-Host "Found Implementation branch with name ${{ env.CURRENT_BRANCH }} so checking it out"
-                git fetch origin ${{ env.CURRENT_BRANCH }}
-                git checkout ${{ env.CURRENT_BRANCH }}
+              $branch_exists = $false
+              $branch_exists = git ls-remote --heads origin $current_branch | Select-String -Pattern $patternName -SimpleMatch -Quiet
+              if ($branch_exists -eq $true) {
+                Write-Host "Current branch exists, so setting to $current_branch"
+                git fetch origin $current_branch
+                git checkout $current_branch
+              } else {
+                Write-Host "did not match on any results for changing ODS checkout branch"
               }
-            }
+           }
     - name: Checkout Ed-Fi-ODS
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:
@@ -86,12 +90,19 @@ jobs:
       working-directory: ./Ed-Fi-ODS/
       shell: pwsh
       run: |
-           $odsBranch = '${{ env.ODS_CURRENT_BRANCH }}'
+           $odsBranch = '${{ env.REPOSITORY_DISPATCH_BRANCH }}'
            Write-Host "OdsBranch: $odsBranch"
            if($odsBranch -ne ''){
-              Write-Host "Checking out ODS branch of $odsBranch"
-              git fetch origin $odsBranch
-              git checkout $odsBranch
+              $patternName = "refs/heads/$odsBranch"
+              $does_corresponding_branch_exist = $false
+              $does_corresponding_branch_exist = git ls-remote --heads origin $odsBranch | Select-String -Pattern $patternName -SimpleMatch -Quiet
+              if ($does_corresponding_branch_exist -eq $true) {
+                Write-Host "Corresponding branch for $odsBranch exists in Implementation repo, so checking it out"
+                git fetch origin odsBranch
+                git checkout odsBranch
+              } else {
+                WriteHost "Corresponding branch for #odsBranch does not exist in Implementation repo, so not changing branch checked out"
+              }
            } else {
               Write-Host "ref_name: ${{env.REF_NAME}}"
               $current_branch = '${{env.REF_NAME}}'
@@ -99,9 +110,8 @@ jobs:
                 Write-Host "ref_name is PR, so using head_ref: ${{env.HEAD_REF}}"
                 $current_branch = '${{env.HEAD_REF}}'
               }
-              
-              Write-Host "Current Branch: $current_branch"
-              $patternName = 'refs/heads/' +  $current_branch
+              $patternName = "refs/heads/$current_branch"
+              Write-Host "Pattern Name is " $patternName -fore GREEN
               $branch_exists = $false
               $branch_exists = git ls-remote --heads origin $current_branch | Select-String -Pattern $patternName -SimpleMatch -Quiet
               if ($branch_exists -eq $true) {

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -26,7 +26,7 @@ env:
   VERSION_MAJOR: "6"
   VERSION_MINOR: "1"
   CURRENT_BRANCH: ${{ GITHUB.HEAD_REF }}
-  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.ref }}
+  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
 
 jobs:

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -25,8 +25,9 @@ env:
   CONFIGURATION: "Release"
   VERSION_MAJOR: "6"
   VERSION_MINOR: "1"
-  CURRENT_BRANCH: ${{ GITHUB.HEAD_REF }}
-  ODS_CURRENT_BRANCH: ${{ github.event.client_payload.branch }}
+  HEAD_REF:  ${{ GITHUB.HEAD_REF }}
+  REF_NAME:  ${{ GITHUB.REF_NAME }}
+  REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
 
 jobs:
@@ -50,39 +51,17 @@ jobs:
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-            $patternName = 'refs/heads/' +  '${{ env.CURRENT_BRANCH }}'
-            Write-Host "Pattern Name is " $patternName -fore GREEN
-            $is_pull_request_branch = 'False'
-            $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
-            if ($is_pull_request_branch -eq $true) {
-              git fetch origin ${{ env.CURRENT_BRANCH }}
-              git checkout ${{ env.CURRENT_BRANCH }}
-            }
+           .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "."
     - name: Checkout Ed-Fi-ODS
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
           path: Ed-Fi-ODS/
     - name: Is pull request branch exists in Ed-Fi-ODS
-      working-directory: ./Ed-Fi-ODS/
+      working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-           $patternName = 'refs/heads/' +  '${{ env.CURRENT_BRANCH }}'
-           Write-Host "Pattern Name is " $patternName -fore GREEN
-           $is_pull_request_branch = 'False'
-           $is_pull_request_branch = git ls-remote --heads origin ${{ env.CURRENT_BRANCH }} | Select-String -Pattern $patternName -SimpleMatch -Quiet
-           Write-Host "pull request branch is '$($is_pull_request_branch -eq $true)'" -fore GREEN
-           $odsBranch = '${{ env.ODS_CURRENT_BRANCH }}'
-           if($odsBranch -ne ''){
-              git fetch origin $odsBranch
-              git checkout $odsBranch
-           } else {
-              if ($is_pull_request_branch -eq $true) {
-                Write-Host "pull request branch " + ${{ env.CURRENT_BRANCH }} + "exists" -fore GREEN
-                git fetch origin ${{ env.CURRENT_BRANCH }}
-                git checkout ${{ env.CURRENT_BRANCH }}
-              }
-           }
+           .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
     - name: Setup Sql Server Connection String
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -7,7 +7,7 @@
 param(
     # Command to execute, defaults to "Build".
     [string]
-    [ValidateSet("Clean", "Build", "Test", "Pack", "Publish")]
+    [ValidateSet("Clean", "Build", "Test", "Pack", "Publish", "CheckoutBranch")]
     $Command = "Build",
 
     [switch] $SelfContained,
@@ -52,7 +52,10 @@ param(
     $TestFilter,
 
     [string]
-    $NuspecFilePath
+    $NuspecFilePath,
+
+    [string]
+    $RepositoryDispatchBranch
 )
 
 $newRevision = ([int]$BuildCounter) + ([int]$BuildIncrementer)
@@ -168,6 +171,41 @@ function Test {
     }
 }
 
+function CheckoutBranch {
+    $odsBranch = $Env:REPOSITORY_DISPATCH_BRANCH
+    Write-Output "OdsBranch: $odsBranch"
+    if($odsBranch -ne ''){
+        $patternName = "refs/heads/$odsBranch"
+        $does_corresponding_branch_exist = $false
+        $does_corresponding_branch_exist = git ls-remote --heads origin $odsBranch | Select-String -Pattern $patternName -SimpleMatch -Quiet
+        if ($does_corresponding_branch_exist -eq $true) {
+            Write-Output "Corresponding branch for $odsBranch exists in Implementation repo, so checking it out"
+            git fetch origin $odsBranch
+            git checkout $odsBranch
+        } else {
+            WriteHost "Corresponding branch for $odsBranch does not exist in Implementation repo, so not changing branch checked out"
+        }
+    } else {
+        Write-Output "ref_name: $Env:REF_NAME"
+        $current_branch = $Env:REF_NAME
+        if ($current_branch -like "*/merge"){
+            Write-Output "ref_name is PR, so using head_ref: $Env:HEAD_REF"
+            $current_branch = $Env:HEAD_REF
+        }
+        $patternName = "refs/heads/$current_branch"
+        Write-Output "Pattern Name is " $patternName -fore GREEN
+        $branch_exists = $false
+        $branch_exists = git ls-remote --heads origin $current_branch | Select-String -Pattern $patternName -SimpleMatch -Quiet
+        if ($branch_exists -eq $true) {
+            Write-Output "Current branch exists, so setting to $current_branch"
+            git fetch origin $current_branch
+            git checkout $current_branch
+        } else {
+            Write-Output "did not match on any results for changing ODS checkout branch"
+        }
+    }
+}
+
 function Invoke-Build {
     Write-Host "Building Version $version" -ForegroundColor Cyan
     Invoke-Step { Clean }
@@ -186,6 +224,10 @@ function Invoke-Pack {
     Invoke-Step { Pack }
 }
 
+function Invoke-CheckoutBranch {
+    Invoke-Step { CheckoutBranch }
+}
+
 Invoke-Main {
     switch ($Command) {
         Clean { Invoke-Clean }
@@ -193,6 +235,7 @@ Invoke-Main {
         Test { Invoke-Tests }
         Pack { Invoke-Pack }
         Publish { Invoke-Publish }
+        CheckoutBranch { Invoke-CheckoutBranch }
         default { throw "Command '$Command' is not recognized" }
     }
 }

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -172,7 +172,7 @@ function Test {
 }
 
 function CheckoutBranch {
-    Set-Locaiont $RelativeRepoPath
+    Set-Location $RelativeRepoPath
     $odsBranch = $Env:REPOSITORY_DISPATCH_BRANCH
     Write-Output "OdsBranch: $odsBranch"
     if($odsBranch -ne ''){

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -55,7 +55,7 @@ param(
     $NuspecFilePath,
 
     [string]
-    $RepositoryDispatchBranch
+    $RelativeRepoPath
 )
 
 $newRevision = ([int]$BuildCounter) + ([int]$BuildIncrementer)
@@ -172,6 +172,7 @@ function Test {
 }
 
 function CheckoutBranch {
+    Set-Locaiont $RelativeRepoPath
     $odsBranch = $Env:REPOSITORY_DISPATCH_BRANCH
     Write-Output "OdsBranch: $odsBranch"
     if($odsBranch -ne ''){

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -194,7 +194,7 @@ function CheckoutBranch {
             $current_branch = "$Env:HEAD_REF"
         }
         $patternName = "refs/heads/$current_branch"
-        Write-Output "Pattern Name is " $patternName -fore GREEN
+        Write-Output "Pattern Name is $patternName" -fore GREEN
         $branch_exists = $false
         $branch_exists = git ls-remote --heads origin $current_branch | Select-String -Pattern $patternName -SimpleMatch -Quiet
         if ($branch_exists -eq $true) {

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -187,10 +187,10 @@ function CheckoutBranch {
         }
     } else {
         Write-Output "ref_name: $Env:REF_NAME"
-        $current_branch = $Env:REF_NAME
+        $current_branch = "$Env:REF_NAME"
         if ($current_branch -like "*/merge"){
             Write-Output "ref_name is PR, so using head_ref: $Env:HEAD_REF"
-            $current_branch = $Env:HEAD_REF
+            $current_branch = "$Env:HEAD_REF"
         }
         $patternName = "refs/heads/$current_branch"
         Write-Output "Pattern Name is " $patternName -fore GREEN


### PR DESCRIPTION
We figured out there were a few situations that the way we were trying to determine which ODS branch to check out would not always work. Namely in these examples:
- If you created a branch for your work in the ODS repo but had no corresponding work in the Implementation repo, when we would try to check out the ODS repo in the workflow, it could not resolve the correct name, as seen [here](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/runs/3201463853/jobs/5229469442#step:7:1) .So then the ODS would end up staying on main instead of your feature branch
- Using HEAD_REF did not always resolve to the correct value, depending on how the workflow was triggered. In the case of it being triggered by a pull request, then HEAD_REF would correctly resolve to the feature branch we created that we opened the pull request for. But then in the context of being manually triggered, or being triggered from the ODS repo, it would resolve as an empty string, since HEAD_REF only works in the context of a pull request. Additionally, we could not switch to using REF_NAME since in the context of a pull request, it would resolve to something like refs/heads/548/merge, since that is the actual branch that triggered the workflow, not our feature branch. But otherwise REF_NAME would work for being triggered manually or from the ODS repo.

Additionally, in talking through it, we realized that when the ODS repo triggers a build in the Implementation repo, we would need to make sure Implementation was checked out to the right branch as well, so similar code was added to the "Is pull request in Ed-Fi-ODs-Implementation" step to see if an ODS branch was passed in the payload, and if so, check that out, otherwise use newer logic to determine the right branch to check out.

So the solution to this was to use a combination of two things:
- Short circuit all checks and first check for the ODS_BRANCH value being set or not, and if so, simply use it
- If not using the ODS_BRANCH, then check if REF_NAME resolved as something like refs/heads/548/merge and if so, use HEAD_REF instead as the branch we want to check out

To show this in action, outside of a workflow, here is some screenshots with a test script I wrote locally to mimic the changes. The test script looked like so:
```
$ref_name = 'ODS-5581b'
$head_ref = ''
$odsBranch = 'ODS-5581b'

Write-Host "OdsBranch: $odsBranch"
if($odsBranch -ne ''){
    Write-Host "Checking out ODS branch of $odsBranch"
    git fetch origin $odsBranch
    git checkout $odsBranch
} else {
    Write-Host "ref_name: $ref_name"
    $current_branch = $ref_name
    if ($current_branch -like "*/merge"){
    Write-Host "ref_name is PR, so using head_ref: $head_ref"
    $current_branch = $head_ref
    }
              
    Write-Host "Current Branch to try and checkout: $current_branch"
    $patternName = 'refs/heads/' +  $current_branch
    $branch_exists = 'False'
    $branch_exists = git ls-remote --heads origin $current_branch | Select-String -Pattern $patternName -SimpleMatch -Quiet
    if ($branch_exists -eq $true) {
    Write-Host "Current branch exists in Ed-Fi-ODS remote, so setting to $current_branch"
    git fetch origin $current_branch
    git checkout $current_branch
    } else {
        Write-Host "did not match on any results for changing ODS checkout branch"
    }
}
```

That example there has the three variables at the top set the way they would be if there was an ODS branch that triggered the Implementation repo that also had a matching branch name, which results in the following results where you can see I started out on main, and then successfully switched to ODS-5581b
![image](https://user-images.githubusercontent.com/1013553/194621253-d16cf576-7f22-4104-91e1-b3453facb99a.png)

Then if the variables are set like so, which would mimic this being triggered by a pull request on the implementation repo:
```
$ref_name = 'refs/heads/548/merge'
$head_ref = 'ODS-5581b'
$odsBranch = ''
```
When the script runs you can see I end up on the ODS-5581b branch:
![image](https://user-images.githubusercontent.com/1013553/194625584-5686ffd4-a940-4fbb-bbcd-e2c127301403.png)

Then if the variables are set like so, which would mimic manually triggering the implementation repo build, on a branch
```
$ref_name = 'ODS-5581b'
$head_ref = ''
$odsBranch = ''
```

You correctly end up on the corresponding ODS feature branch:
![image](https://user-images.githubusercontent.com/1013553/194628570-967f262b-0d22-498a-9685-7685975ff33d.png)

Then if the variables are set like so, which would mimic manually triggering the implementation repo build, on main
```
$ref_name = 'main'
$head_ref = ''
$odsBranch = ''
```

You correctly stay on main for ODS:
![image](https://user-images.githubusercontent.com/1013553/194629132-f9703a99-35bb-46d8-b921-404003c48b9b.png)
