### PR TITLE
ODS-5375 - Update Script Group 6 to support PS7 and Unix

### DIFF
--- a/Scripts/NuGet/EdFi.RestApi.Databases/Deployment.psm1
+++ b/Scripts/NuGet/EdFi.RestApi.Databases/Deployment.psm1
@@ -13,7 +13,7 @@ $script:deploymentSettingsOverrides = @{ }
 function Initialize-DeploymentEnvironment {
     <#
     .description
-        Deploy databases from the EdFi.RestApi.Databases NuGet package created by .\prep-package.ps1
+        Deploy databases from the EdFi.RestApi.Databases NuGet package created by ./prep-package.ps1
     .parameter PathResolverRepositoryOverride
         A semicolon-separated string of repositories to pass to path-resolver, such as 'Ed-Fi-ODS;Ed-Fi-Ods-Implementation'
     .parameter InstallType
@@ -68,9 +68,9 @@ function Initialize-DeploymentEnvironment {
     )
 
     # if path-resolver is not present assume that the script is being ran in a deployment scenario
-    # from inside the EdFi.RestApi.Databases NuGet Package created by .\prep-package.ps1
+    # from inside the EdFi.RestApi.Databases NuGet Package created by ./prep-package.ps1
     if (-not (Get-Module | Where-Object -Property Name -eq 'path-resolver')) {
-        $pathResolver = (Get-ChildItem "$PSScriptRoot\*\logistics\scripts\modules\load-path-resolver.ps1" | Select-Object -Last 1)
+        $pathResolver = (Get-ChildItem "$PSScriptRoot/*/logistics/scripts/modules/load-path-resolver.ps1" | Select-Object -Last 1)
 
         if ([string]::IsNullOrWhiteSpace($PathResolverRepositoryOverride)) {
             & $pathResolver
@@ -81,13 +81,13 @@ function Initialize-DeploymentEnvironment {
         $env:toolsPath = (Join-Path (Get-RootPath) 'tools')
     }
 
-    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'DatabaseTemplate\Modules\database-template-source.psm1')
-    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\database\database-lifecycle.psm1')
-    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\settings\settings-management.psm1')
-    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\tasks\TaskHelper.psm1")
-    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\tools\ToolsHelper.psm1')
-    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\utility\hashtable.psm1')
-    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\plugin\plugin-source.psm1')
+    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'DatabaseTemplate/Modules/database-template-source.psm1')
+    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/database/database-lifecycle.psm1')
+    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/settings/settings-management.psm1')
+    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/tasks/TaskHelper.psm1")
+    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/tools/ToolsHelper.psm1')
+    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/hashtable.psm1')
+    Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/plugin/plugin-source.psm1')
 
     Write-InvocationInfo $MyInvocation
 
@@ -157,7 +157,7 @@ function Set-DeploymentSettingsFiles([string[]] $DeploymentSettingsFiles) {
         when using initdev this uses
             appsettings.json, appsettings.Development.json, appsettings.user.json from the EdFi.Ods.WebApi project
         when using EdFi.RestApi.Databases for deployment this uses
-            Ed-Fi-ODS-Implementation\Scripts\NuGet\EdFi.RestApi.Databases\configuration.json
+            Ed-Fi-ODS-Implementation/Scripts/NuGet/EdFi.RestApi.Databases/configuration.json
     #>
 
     $script:deploymentSettingsFiles = $DeploymentSettingsFiles

--- a/Scripts/NuGet/EdFi.RestApi.Databases/prep-package.ps1
+++ b/Scripts/NuGet/EdFi.RestApi.Databases/prep-package.ps1
@@ -10,11 +10,11 @@ Prepare the EdFi.RestApi.Databases nuspec file for use with 'nuget pack'
 .notes
 The format of the EdFi Database Deployment NuGet package:
 
-Everything we add belongs in the lib\ folder. As we are not a tool intended to be invoked from with Visual Studio, this is correct per the NuGet package spec.
+Everything we add belongs in the lib/ folder. As we are not a tool intended to be invoked from with Visual Studio, this is correct per the NuGet package spec.
 
-That said, at this time we are not breaking out by .NET version, even for executables and DLLs we place in the lib\ folder. This is acceptable and in line with the spec as well.
+That said, at this time we are not breaking out by .NET version, even for executables and DLLs we place in the lib/ folder. This is acceptable and in line with the spec as well.
 
-Powershell and database scripts belong in a repository-specific folder, and should retain their relative paths to that folder. So, 'Database\Data\EduId' in an Ed-Fi-Apps repository would go in 'lib\Ed-Fi-Apps\Database\Data\EduId'.
+Powershell and database scripts belong in a repository-specific folder, and should retain their relative paths to that folder. So, 'Database/Data/EduId' in an Ed-Fi-Apps repository would go in 'lib/Ed-Fi-Apps/Database/Data/EduId'.
 
 As only one .nuspec file can be used to generate a given NuGet package, the least generic repository (traditionally called Ed-Fi-Apps) must contain references to all files, even ones in other, less generic repositories (such as Ed-Fi-Core).
 
@@ -29,14 +29,14 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-& "$PSScriptRoot\..\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'DatabaseTemplate\Modules\database-template-source.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\config\config-management.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\settings\settings-management.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\database\database-lifecycle.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\packaging\packaging.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\tasks\TaskHelper.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\plugin\plugin-source.psm1')
+& "$PSScriptRoot/../../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'DatabaseTemplate/Modules/database-template-source.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/config/config-management.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/settings/settings-management.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/database/database-lifecycle.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/packaging/packaging.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/tasks/TaskHelper.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/plugin/plugin-source.psm1')
 
 Clear-Error
 
@@ -52,7 +52,7 @@ function Select-ExtensionAssemblyMetadataJson {
 
 if (-not $outputDirectory) { $outputDirectory = $PSScriptRoot } # Note: this cannot be done in the param block. $PSScriptRoot is not available at that time.
 
-$nuspecPath = "$outputDirectory\$packageName.nuspec"
+$nuspecPath = "$outputDirectory/$packageName.nuspec"
 
 $nuspecArgs = @{
     forceOverwrite = $true
@@ -83,8 +83,8 @@ $repoNuspecFiles = @(
     Select-ExtensionAssemblyMetadataJson
 
     # Add the License and Notices files
-    "$PSScriptRoot\..\..\..\LICENSE.txt"
-    "$PSScriptRoot\..\..\..\NOTICES.md"
+    "$PSScriptRoot/../../../LICENSE.txt"
+    "$PSScriptRoot/../../../NOTICES.md"
 )
 Add-RepositoryFileToNuspec -nuspecPath $nuspecPath -file $repoNuspecFiles
 
@@ -95,9 +95,9 @@ $nonrepoNuspecFiles = Get-ChildItem $outputDirectory -Exclude *.nuspec, prep-pac
 
 Add-FileToNuspec -nuspecPath $nuspecPath -sourceTargetPair $nonrepoNuspecFiles
 
-Add-FileToNuspec -nuspecPath $nuspecPath -sourceTargetPair  @{ source = Select-CumulativeRepositoryResolvedItems "tools\EdFi.Db.Deploy.exe"; target = "tools" }
+Add-FileToNuspec -nuspecPath $nuspecPath -sourceTargetPair  @{ source = Select-CumulativeRepositoryResolvedItems "tools/EdFi.Db.Deploy.exe"; target = "tools" }
 
-$dbDeployToolfiles = @(((Select-CumulativeRepositoryResolvedItems -recurse "tools\.store\EdFi.Suite3.Db.Deploy" ) |  Where-Object { -not $_.Name.EndsWith(".nupkg")} ))
+$dbDeployToolfiles = @(((Select-CumulativeRepositoryResolvedItems -recurse "tools/.store/EdFi.Suite3.Db.Deploy" ) |  Where-Object { -not $_.Name.EndsWith(".nupkg")} ))
 
 Foreach ($eachtoolfile in $dbDeployToolfiles)
 {

--- a/Scripts/NuGet/EdFi.RestApi.Databases/prep-package.ps1
+++ b/Scripts/NuGet/EdFi.RestApi.Databases/prep-package.ps1
@@ -98,7 +98,7 @@ Add-FileToNuspec -nuspecPath $nuspecPath -sourceTargetPair $nonrepoNuspecFiles
 
 Add-FileToNuspec -nuspecPath $nuspecPath -sourceTargetPair  @{ source = Select-CumulativeRepositoryResolvedItems @(If (Get-IsWindows) { "tools/EdFi.Db.Deploy.exe" } Else { "tools/EdFi.Db.Deploy" }) ; target = "tools" }
 
-$dbDeployToolfiles = @(((Select-CumulativeRepositoryResolvedItems -recurse "tools/.store/EdFi.Suite3.Db.Deploy" ) |  Where-Object { -not $_.Name.EndsWith(".nupkg")} ))
+$dbDeployToolfiles = @(((Select-CumulativeRepositoryResolvedItems -recurse "tools/.store/edfi.suite3.db.deploy" ) |  Where-Object { -not $_.Name.EndsWith(".nupkg")} ))
 
 Foreach ($eachtoolfile in $dbDeployToolfiles)
 {

--- a/Scripts/NuGet/EdFi.RestApi.Databases/prep-package.ps1
+++ b/Scripts/NuGet/EdFi.RestApi.Databases/prep-package.ps1
@@ -33,6 +33,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'DatabaseTemplate/Modules/database-template-source.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/config/config-management.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/settings/settings-management.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/utility/cross-platform.psm1")
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/database/database-lifecycle.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/packaging/packaging.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/tasks/TaskHelper.psm1')
@@ -95,7 +96,7 @@ $nonrepoNuspecFiles = Get-ChildItem $outputDirectory -Exclude *.nuspec, prep-pac
 
 Add-FileToNuspec -nuspecPath $nuspecPath -sourceTargetPair $nonrepoNuspecFiles
 
-Add-FileToNuspec -nuspecPath $nuspecPath -sourceTargetPair  @{ source = Select-CumulativeRepositoryResolvedItems "tools/EdFi.Db.Deploy.exe"; target = "tools" }
+Add-FileToNuspec -nuspecPath $nuspecPath -sourceTargetPair  @{ source = Select-CumulativeRepositoryResolvedItems @(If (Get-IsWindows) { "tools/EdFi.Db.Deploy.exe" } Else { "tools/EdFi.Db.Deploy" }) ; target = "tools" }
 
 $dbDeployToolfiles = @(((Select-CumulativeRepositoryResolvedItems -recurse "tools/.store/EdFi.Suite3.Db.Deploy" ) |  Where-Object { -not $_.Name.EndsWith(".nupkg")} ))
 

--- a/logistics/scripts/activities/build/promote-packages.ps1
+++ b/logistics/scripts/activities/build/promote-packages.ps1
@@ -23,7 +23,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-& "$PSScriptRoot\..\..\..\..\logistics\scripts\modules\load-path-resolver.ps1"
+& "$PSScriptRoot/../../../../logistics/scripts/modules/load-path-resolver.ps1"
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/packaging/promotion.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/settings/settings-management.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/hashtable.psm1')

--- a/logistics/scripts/modules/LoadTools.psm1
+++ b/logistics/scripts/modules/LoadTools.psm1
@@ -6,10 +6,10 @@
 
 $ErrorActionPreference = "Stop"
 
-& "$PSScriptRoot\..\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\tasks\TaskHelper.psm1")
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\packaging\restore-packages.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\settings\settings-management.psm1')
+& "$PSScriptRoot/../../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/tasks/TaskHelper.psm1")
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/packaging/restore-packages.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/settings/settings-management.psm1')
 
 function Invoke-BuildLoadTools {
     param(

--- a/logistics/scripts/modules/LoadTools.psm1
+++ b/logistics/scripts/modules/LoadTools.psm1
@@ -124,7 +124,7 @@ function Invoke-BulkLoadClient {
     $bulkLoadDirectoryData = $config.bulkLoadDirectoryData
     $bulkLoadDirectoryMetadata = $config.bulkLoadDirectoryMetadata -replace '\\', '/'
     $bulkLoadDirectoryWorking = $config.bulkLoadDirectoryWorking -replace '\\', '/'
-    $bulkLoadForceReloadMetadata = $config.bulkLoadForceReloadMetadata -replace '\\', '/'
+    $bulkLoadForceReloadMetadata = $config.bulkLoadForceReloadMetadata
     $bulkLoadMaxRequests = $config.bulkLoadMaxRequests
     $BulkLoadNoXmlValidation = $config.BulkLoadNoXmlValidation
     $bulkLoadRetries = $config.bulkLoadRetries

--- a/logistics/scripts/modules/build-management.psm1
+++ b/logistics/scripts/modules/build-management.psm1
@@ -6,12 +6,12 @@
 
 $ErrorActionPreference = "Stop"
 
-& "$PSScriptRoot\..\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\config\config-management.psm1")
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\settings\settings-management.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\database\database-management.psm1")
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\database\postgres-database-management.psm1")
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\tasks\TaskHelper.psm1")
+& "$PSScriptRoot/../../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/config/config-management.psm1")
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/settings/settings-management.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/database/database-management.psm1")
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/database/postgres-database-management.psm1")
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/tasks/TaskHelper.psm1")
 
 function Remove-EdFiSQLServerDatabases {
     <#


### PR DESCRIPTION
Most changes here were simple path fixes, but a few other notable changes were:

- Updating a path to the DbDeploy tool in the .store folder to be lowercase since in Ubuntu it named the folder with all lowercase letters
- Checking for Windows to determine if we use the DbDeploy exe or not in the nuspec file for the Database package we build.

Since this centered around package prep, below is an example of a powershell script I used to test out the RestApi.Database package prep and creation to confirm the scripts worked after updating, and then I compared the package contents to ensure they were matching:

```
& "./Initialize-PowershellForDevelopment.ps1"

$params = @{
    DatabaseId = 'EdFi.Suite3.RestApi.Databases'
    PackageVersion = '0.0.0'
    PackageOutput = './packages'
}

$parameters = @{
    ProjectPath     = (Get-RepositoryResolvedPath (Get-ProjectTypes).Databases)
    PackageId       = $params.DatabasesId
    Version         = $params.PackageVersion
    Properties      = (Get-DefaultNuGetProperties)
    OutputDirectory = $params.PackageOutput
}

New-DatabasesPackage @parameters
```