### PR TITLE
ODS-5557 - Fix building of Postgres minimal template

### DIFF
--- a/DatabaseTemplate/Modules/create-database-template.psm1
+++ b/DatabaseTemplate/Modules/create-database-template.psm1
@@ -503,7 +503,13 @@ function New-DatabaseTemplateNuspec {
         [hashtable] $config
     )
     $packageNuspecName = $config.packageNuspecName
-    if ($config.engine -eq 'PostgreSQL') { $packageNuspecName += ".PostgreSQL" }
+    if ($config.engine -eq 'PostgreSQL') {
+        $packageNuspecName += ".PostgreSQL"
+        $config.databaseBackupName += ".PostgreSQL"
+        $config.Id += ".PostgreSQL"
+        $config.Title += ".PostgreSQL"
+        $config.Description = "EdFi Ods Minimal Template Database for PostgreSQL"
+    }
 
     if (-not $config.backupDirectory) { $populatedTemplatePath = $global:templateDatabaseFolder }
     else { $populatedTemplatePath = $config.backupDirectory }

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -12,7 +12,7 @@
     },
     "PostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL",
-      "PackageVersion": "6.1.9",
+      "PackageVersion": "6.1.30",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlPopulatedTemplate": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -7,7 +7,7 @@
     },
     "GrandBend": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template",
-      "PackageVersion": "6.1.15",
+      "PackageVersion": "6.1.111",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlMinimalTemplate": {
@@ -27,7 +27,7 @@
     },
     "TPDMCorePopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core",
-      "PackageVersion": "6.1.11",
+      "PackageVersion": "6.1.63",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlMinimalTemplate": {


### PR DESCRIPTION
After recent changes, it meant that the Minimal Template Postgres build was not correctly being named with ".PostgreSQL" at the end of the name. The script previously set the nuspec name correctly to include ".PostgreSQL", but the other nuspec properties were not set, so when nuget pack was called, it was not creating the correct package file name based on the id.

To see this issue, if you look at a previous build for the Minimal Postgres template [here](https://intedfitools1.msdf.org/buildConfiguration/OdsPlatform_OdsApi_Packages_EdFiOdsMinimalTemplatePostgreSQL/184422?buildTab=artifacts), you can see on this one how the nuget package is called EdFi.Suite3.Ods.Minimal.Template when it should be called EdFi.Suite3.Ods.Minimal.Template.PostgreSQL. [Here](https://intedfitools1.msdf.org/buildConfiguration/OdsPlatform_OdsApi_Packages_EdFiOdsMinimalTemplatePostgreSQL/184493?buildTab=artifacts) is a build from this branch showing it with the correct name now.