### PR TITLE
[ODS-5376] Support PS 7.2 and Unix - Script group 7

### DIFF
--- a/DatabaseTemplate/Modules/create-database-template.psm1
+++ b/DatabaseTemplate/Modules/create-database-template.psm1
@@ -6,7 +6,7 @@
 $ErrorActionPreference = "Stop"
 
 
-& "$PSScriptRoot\..\..\logistics\scripts\modules\load-path-resolver.ps1"
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'DatabaseTemplate/Modules/database-template-source.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/config/config-management.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/database/database-lifecycle.psm1')
@@ -47,7 +47,8 @@ function Get-DefaultTemplateConfiguration([hashtable] $config = @{ }) {
     $config.apiClientNameSandbox = "BulkLoadClientSandbox"
     $config.apiYear = (Get-Date).Year
 
-    $config.testHarnessExecutable = "$($config.outputFolder)/EdFi.Ods.Api.IntegrationTestHarness.exe"
+    $integrationTestHarnessExecutableFileName = If (Get-IsWindows) {"EdFi.Ods.Api.IntegrationTestHarness.exe"} Else {"EdFi.Ods.Api.IntegrationTestHarness"}
+    $config.testHarnessExecutable = "$($config.outputFolder)/$integrationTestHarnessExecutableFileName"
     $config.testHarnessJsonConfig = "$PSScriptRoot/testHarnessConfiguration.json"
     $config.testHarnessJsonConfigLEAs = @(255901)
 
@@ -146,8 +147,8 @@ function Copy-SchemaFiles {
         $xsdFiles = Get-ChildItem (resolve-path $schemaDirectory) -Recurse -Filter "*.xsd"
         foreach ($xsdFile in $xsdFiles) {
             $elapsed = Use-Stopwatch {
-                Write-Host "copy to $($directory.Name)\$($xsdFile.Name) " -NoNewline
-                Copy-Item -Path $xsdFile.FullName -Destination "$directory\$xsdFile"
+                Write-Host "copy to $($directory.Name)/$($xsdFile.Name) " -NoNewline
+                Copy-Item -Path $xsdFile.FullName -Destination "$directory/$xsdFile"
             }
             Write-Host $elapsed.duration -ForegroundColor DarkGray
         }
@@ -168,8 +169,8 @@ function Copy-InterchangeFiles {
     foreach ($xmlFile in $xmlFiles) {
         if ($includeAllInterchanges -or ($interchanges -contains (Get-XmlRoot $xmlFile.FullName).Name)) {
             $elapsed = Use-Stopwatch {
-                Write-Host "copy to $($directory.Name)\$($xmlFile.Name) " -NoNewline
-                Copy-Item -Path $xmlFile.FullName -Destination "$directory\$($xmlFile.Name)"
+                Write-Host "copy to $($directory.Name)/$($xmlFile.Name) " -NoNewline
+                Copy-Item -Path $xmlFile.FullName -Destination "$directory/$($xmlFile.Name)"
             }
             Write-Host $elapsed.duration -ForegroundColor DarkGray
         }

--- a/DatabaseTemplate/Modules/create-database-template.psm1
+++ b/DatabaseTemplate/Modules/create-database-template.psm1
@@ -7,25 +7,25 @@ $ErrorActionPreference = "Stop"
 
 
 & "$PSScriptRoot\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'DatabaseTemplate\Modules\database-template-source.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\config\config-management.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\database\database-lifecycle.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\database\database-management.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\database\postgres-database-management.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\LoadTools.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\packaging\nuget-helper.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\packaging\packaging.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\packaging\restore-packages.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\tasks\TaskHelper.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\TestHarness.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\utility\hashtable.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\utility\xml-validation.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'Scripts\NuGet\EdFi.RestApi.Databases\Deployment.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'DatabaseTemplate/Modules/database-template-source.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/config/config-management.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/database/database-lifecycle.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/database/database-management.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/database/postgres-database-management.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/LoadTools.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/packaging/nuget-helper.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/packaging/packaging.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/packaging/restore-packages.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/tasks/TaskHelper.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/TestHarness.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/hashtable.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/xml-validation.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'Scripts/NuGet/EdFi.RestApi.Databases/Deployment.psm1')
 
 function Get-DefaultTemplateConfiguration([hashtable] $config = @{ }) {
 
     $config = Merge-Hashtables $config, (Get-EnvironmentConfiguration $config)
-    $config.outputFolder = (Get-ChildItem "$(Get-RepositoryResolvedPath "Application\EdFi.Ods.Api.IntegrationTestHarness")\bin\**\*").FullName
+    $config.outputFolder = (Get-ChildItem "$(Get-RepositoryResolvedPath "Application/EdFi.Ods.Api.IntegrationTestHarness")/bin/**/*").FullName
     
     # Since not all features are enabled by default for database templates, an appsettings.json specifically intended for database generation is copied to
     # the Integration Test Harness output folder to overwrite the appsettings.json file otherwise used by the Integration Test Harness
@@ -47,15 +47,16 @@ function Get-DefaultTemplateConfiguration([hashtable] $config = @{ }) {
     $config.apiClientNameSandbox = "BulkLoadClientSandbox"
     $config.apiYear = (Get-Date).Year
 
-    $config.testHarnessExecutable = "$($config.outputFolder)\EdFi.Ods.Api.IntegrationTestHarness.exe"
-    $config.testHarnessJsonConfig = "$PSScriptRoot\testHarnessConfiguration.json"
+    $config.testHarnessExecutable = "$($config.outputFolder)/EdFi.Ods.Api.IntegrationTestHarness.exe"
+    $config.testHarnessJsonConfig = "$PSScriptRoot/testHarnessConfiguration.json"
     $config.testHarnessJsonConfigLEAs = @(255901)
 
-    $config.loadToolsSolution = (Get-RepositoryResolvedPath "Utilities\DataLoading\LoadTools.sln")
-    $config.bulkLoadClientExecutable = "$(Get-RepositoryResolvedPath "Utilities\DataLoading\EdFi.BulkLoadClient.Console")\bin\**\EdFi.BulkLoadClient.Console.exe"
+    $config.loadToolsSolution = (Get-RepositoryResolvedPath "Utilities/DataLoading/LoadTools.sln")
+    $bulkLoadClientExecutableFileName = If (Get-IsWindows) {"EdFi.BulkLoadClient.Console.exe"} Else {"EdFi.BulkLoadClient.Console"}
+    $config.bulkLoadClientExecutable = "$(Get-RepositoryResolvedPath "Utilities/DataLoading/EdFi.BulkLoadClient.Console")/bin/**/$bulkLoadClientExecutableFileName"
     $config.bulkLoadBootstrapInterchanges = @("InterchangeDescriptors", "InterchangeStandards", "InterchangeEducationOrganization")
-    $config.bulkLoadDirectoryMetadata = (Get-RepositoryResolvedPath "Application\EdFi.Ods.Standard\Artifacts\Metadata\")
-    $config.bulkLoadTempDirectory = Join-Path $env:temp "CreateDatabaseTemplate"
+    $config.bulkLoadDirectoryMetadata = (Get-RepositoryResolvedPath "Application/EdFi.Ods.Standard/Artifacts/Metadata/")
+    $config.bulkLoadTempDirectory = Join-Path ([IO.Path]::GetTempPath()) "CreateDatabaseTemplate"
     $config.bulkLoadTempDirectorySchema = Join-Path $config.bulkLoadTempDirectory "Schemas"
     $config.bulkLoadTempDirectoryBootstrap = Join-Path $config.bulkLoadTempDirectory "Bootstrap"
     $config.bulkLoadTempDirectorySample = Join-Path $config.bulkLoadTempDirectory "Sample"

--- a/DatabaseTemplate/Modules/create-minimal-template.psm1
+++ b/DatabaseTemplate/Modules/create-minimal-template.psm1
@@ -6,8 +6,8 @@
 
 $ErrorActionPreference = "Stop"
 
-& "$PSScriptRoot\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate\Modules\create-database-template.psm1")
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/create-database-template.psm1")
 
 function Get-MinimalConfiguration([hashtable] $config = @{ }) {
 

--- a/Scripts/NuGet/EdFi.RestApi.Databases/PostDeploy.ps1
+++ b/Scripts/NuGet/EdFi.RestApi.Databases/PostDeploy.ps1
@@ -52,5 +52,7 @@ Add-Parameter $deploymentParams 'ExcludedExtensionSources' $ExcludedExtensionSou
 Add-Parameter $deploymentParams 'EnabledFeatureNames' $EnabledFeatureNames
 if ([Boolean]::TryParse((Add-Parameter $deploymentParams 'UsePlugins' $UsePlugins).UsePlugins, [ref]$UsePlugins)) { $deploymentParams.UsePlugins = $UsePlugins }
 
-Import-Module -Force -Scope Global "$PSScriptRoot\Deployment.psm1"
+If (-Not(Get-IsWindows)) {Add-Parameter $deploymentParams 'Engine' "PostgreSQL"} 
+
+Import-Module -Force -Scope Global "$PSScriptRoot/Deployment.psm1"
 Initialize-DeploymentEnvironment @deploymentParams

--- a/logistics/scripts/run-smoke-tests.ps1
+++ b/logistics/scripts/run-smoke-tests.ps1
@@ -69,7 +69,8 @@ if ([string]::IsNullOrWhiteSpace($key)) { $key = Get-RandomString }
 if ([string]::IsNullOrWhiteSpace($secret)) { $secret = Get-RandomString }
 
 if ([string]::IsNullOrWhiteSpace($smokeTestExe) -or -not (Test-Path $smokeTestExe)) {
-    $smokeTestExe = "$(Get-RepositoryResolvedPath "Utilities/DataLoading/EdFi.SmokeTest.Console")/bin/**/EdFi.SmokeTest.Console.exe"
+    $smokeTestExeFileName = If (Get-IsWindows) {"EdFi.SmokeTest.Console.exe"} Else {"EdFi.SmokeTest.Console"}
+    $smokeTestExe = "$(Get-RepositoryResolvedPath "Utilities/DataLoading/EdFi.SmokeTest.Console")/bin/**/$smokeTestExeFileName"
 }
 else { $noRebuild = $true }
 

--- a/logistics/scripts/run-smoke-tests.ps1
+++ b/logistics/scripts/run-smoke-tests.ps1
@@ -99,7 +99,7 @@ function Get-SmokeTestConfiguration {
     $config.testHarnessJsonConfig = "$(Get-RepositoryResolvedPath "logistics\scripts\smokeTestHarnessConfiguration.json")"
     $config.testHarnessJsonConfigLEAs = @()
 
-    $config.bulkLoadTempJsonConfig = Join-Path $env:temp "smokeTestconfig.json"
+    $config.bulkLoadTempJsonConfig = Join-Path ([IO.Path]::GetTempPath()) "smokeTestconfig.json"
 
     $config.buildConfiguration = "Debug"
     if (-not [string]::IsNullOrWhiteSpace($env:msbuild_buildConfiguration)) { $config.buildConfiguration = $env:msbuild_buildConfiguration }

--- a/logistics/scripts/run-smoke-tests.ps1
+++ b/logistics/scripts/run-smoke-tests.ps1
@@ -49,8 +49,8 @@ param(
     [string] $namespaceUri = "uri://ed-fi.org/",
     [string] $schoolYear = $null,
     [string[]] $testSets = @("NonDestructiveApi"),
-    [string] $smokeTestExe = ".\EdFi.SmokeTest.Console\tools\EdFi.SmokeTest.Console.exe",
-    [string] $smokeTestDll = ".\EdFi.OdsApi.Sdk\lib\EdFi.OdsApi.Sdk.dll",
+    [string] $smokeTestExe = "./EdFi.SmokeTest.Console/tools/EdFi.SmokeTest.Console.exe",
+    [string] $smokeTestDll = "./EdFi.OdsApi.Sdk/lib/EdFi.OdsApi.Sdk.dll",
     [switch] $noRebuild,
     [string] $testHarnessLogNamePrefix
 )
@@ -59,22 +59,22 @@ $ErrorActionPreference = 'Stop'
 
 $error.Clear()
 
-& "$PSScriptRoot\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\LoadTools.psm1')
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\TestHarness.psm1")
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics\scripts\modules\tasks\TaskHelper.psm1")
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics\scripts\modules\utility\hashtable.psm1')
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/LoadTools.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/TestHarness.psm1")
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/tasks/TaskHelper.psm1")
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/hashtable.psm1')
 
 if ([string]::IsNullOrWhiteSpace($key)) { $key = Get-RandomString }
 if ([string]::IsNullOrWhiteSpace($secret)) { $secret = Get-RandomString }
 
 if ([string]::IsNullOrWhiteSpace($smokeTestExe) -or -not (Test-Path $smokeTestExe)) {
-    $smokeTestExe = "$(Get-RepositoryResolvedPath "Utilities\DataLoading\EdFi.SmokeTest.Console")\bin\**\EdFi.SmokeTest.Console.exe"
+    $smokeTestExe = "$(Get-RepositoryResolvedPath "Utilities/DataLoading/EdFi.SmokeTest.Console")/bin/**/EdFi.SmokeTest.Console.exe"
 }
 else { $noRebuild = $true }
 
 if ([string]::IsNullOrWhiteSpace($smokeTestDll) -or -not(Test-Path $smokeTestDll)) {
-    $smokeTestDll = "$(Get-RepositoryResolvedPath "Utilities\DataLoading\EdFi.LoadTools.Test")\bin\**\EdFi.OdsApi.Sdk.dll"
+    $smokeTestDll = "$(Get-RepositoryResolvedPath "Utilities/DataLoading/EdFi.LoadTools.Test")/bin/**/EdFi.OdsApi.Sdk.dll"
 }
 
 function Get-SmokeTestConfiguration {
@@ -88,15 +88,15 @@ function Get-SmokeTestConfiguration {
     $config.apiYear = $schoolYear
     $config.smokeTestExecutable = $smokeTestExe
     $config.smokeTestDll = $smokeTestDll
-    $config.apiAppConfig = "$(Get-RepositoryResolvedPath "Application\EdFi.Ods.Api.IntegrationTestHarness")\bin\**\appsettings.json"
+    $config.apiAppConfig = "$(Get-RepositoryResolvedPath "Application/EdFi.Ods.Api.IntegrationTestHarness")/bin/**/appsettings.json"
     $config.noExtensions = $false
 
     $config.testSets = $testSets
 
-    $config.loadToolsSolution = (Get-RepositoryResolvedPath "Utilities\DataLoading\LoadTools.sln")
+    $config.loadToolsSolution = (Get-RepositoryResolvedPath "Utilities/DataLoading/LoadTools.sln")
 
-    $config.testHarnessAppConfig = "$(Get-RepositoryResolvedPath "Application\EdFi.Ods.Api.IntegrationTestHarness")\bin\**\appsettings.json"
-    $config.testHarnessJsonConfig = "$(Get-RepositoryResolvedPath "logistics\scripts\smokeTestHarnessConfiguration.json")"
+    $config.testHarnessAppConfig = "$(Get-RepositoryResolvedPath "Application/EdFi.Ods.Api.IntegrationTestHarness")/bin/**/appsettings.json"
+    $config.testHarnessJsonConfig = "$(Get-RepositoryResolvedPath "logistics/scripts/smokeTestHarnessConfiguration.json")"
     $config.testHarnessJsonConfigLEAs = @()
 
     $config.bulkLoadTempJsonConfig = Join-Path ([IO.Path]::GetTempPath()) "smokeTestconfig.json"


### PR DESCRIPTION
NOTE - the ticket did not call for updated create-minimal-template.ps1.  However, the changes were minor and it allowed for easier testing of the changes to create-database-template.ps1

Changes:

1. Replaced back slashes with forward slashes
2. On non-windows environments removed the .exe extension from executable file name references
3. Replaced OS specific environment variables with cross-platform equivalent references
4. On PostDeploy.ps1 added a parameter of Engine PosgreSQL for non-windows machines

Steps to test:
1. Update line 363 of InitializeDevelopmentEnvironment.psm1, removing the ToLower() function call so the line looks like `"-r", $RespositoryRoot,`)
5. `initdev -Engine PostgreSQL`
6. Checkout tag 4.0.0-a on Ed-Fi-Standard
7. `Initialize-MinimalTemplate -samplePath <root directory to Ed-Fi-Standard> -Engine PostgreSQL`