### PR TITLE
ODS-5609 - Add test reporting to InitDev builds

### DIFF
--- a/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
+++ b/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
@@ -71,21 +71,30 @@ jobs:
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
         .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -NoPackaging
       shell: pwsh
-    - name: Upload Test Reports
+    - name: Upload Unit And Integration Test Reports
       if: success() || failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
       with:
         name: test-results
         path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/
-    - name: Test Report
+    - name: Unit Test Report
       uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6
       if: success() || failure()
       with:
-        name: Integration and Unit Tests
+        name: Unit Tests
         path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/*.trx
         path-replace-backslashes: 'true'
         working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
         reporter: dotnet-trx
+    - name: Postman Test Report
+      uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6
+      if: success() || failure()
+      with:
+        name: Integration Tests
+        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/*.xml
+        path-replace-backslashes: 'true'
+        working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
+        reporter: java-junit
     - name: Upload initdev logs
       if: success() || failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
+++ b/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
@@ -71,6 +71,21 @@ jobs:
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
         .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -NoPackaging
       shell: pwsh
+    - name: Upload Test Reports
+      if: success() || failure()
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+      with:
+        name: test-results
+        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/
+    - name: Test Report
+      uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6
+      if: success() || failure()
+      with:
+        name: Integration and Unit Tests
+        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/*.trx
+        path-replace-backslashes: 'true'
+        working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
+        reporter: dotnet-trx
     - name: Upload initdev logs
       if: success() || failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -99,6 +99,7 @@ jobs:
         name: Integration and Unit Tests
         path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/*.trx
         reporter: dotnet-trx
+        working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
     - name: Upload initdev logs
       if: success() || failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -103,11 +103,10 @@ jobs:
       if: success() || failure()
       with:
         name: Integration and Unit Tests
-        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/EdFi.Ods.Repositories.NHibernate.Tests.dll.trx
+        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/*.trx
         path-replace-backslashes: 'true'
         working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
         reporter: dotnet-trx
-        only-summary: 'false'
     - name: Upload initdev logs
       if: success() || failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -92,6 +92,13 @@ jobs:
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
         .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -PackageOutput "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/NugetPackages"
       shell: pwsh
+    - name: Test Report
+      uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6
+      if: success() || failure()
+      with:
+        name: Integration and Unit Tests
+        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/*.trx
+        reporter: dotnet-trx
     - name: Upload initdev logs
       if: success() || failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -107,6 +107,7 @@ jobs:
         path-replace-backslashes: 'true'
         working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
         reporter: dotnet-trx
+        only-summary: 'false'
     - name: Upload initdev logs
       if: success() || failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -60,28 +60,11 @@ jobs:
       shell: pwsh
       run: |
            .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
-    - name: Setup Sql Server Connection String
-      working-directory: ./Ed-Fi-ODS-Implementation/
+    - name: Install sql-server-2019 & sqlpackage
+      shell: powershell
       run: |
-        $ErrorActionPreference = 'Stop'
-        $PSVersionTable
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-           
-        # EdFi.Ods.WebApi
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ec 'ConnectionStrings:EdFi_Ods'      'Server=(LocalDB)\\MSSQLLocalDB; Database=EdFi_{0}; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.WebApi;'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ec 'ConnectionStrings:EdFi_Admin'    'Server=(LocalDB)\\MSSQLLocalDB; Database=EdFi_Admin; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.WebApi;'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ec 'ConnectionStrings:EdFi_Security' 'Server=(LocalDB)\\MSSQLLocalDB; Database=EdFi_Security; Connection Timeout=30; Trusted_Connection=True; Persist Security Info=True; Application Name=EdFi.Ods.WebApi;'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ec 'ConnectionStrings:EdFi_Master'   'Server=(LocalDB)\\MSSQLLocalDB; Database=master; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.WebApi;'
-
-        # EdFi.Ods.Api.IntegrationTestHarness
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ed 'ConnectionStrings:EdFi_Ods'      'Server=(LocalDB)\MSSQLLocalDB; Database=EdFi_Ods_Populated_Template_Test; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.Api.IntegrationTestHarness'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ed 'ConnectionStrings:EdFi_Admin'    'Server=(LocalDB)\MSSQLLocalDB; Database=EdFi_Admin; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.Api.IntegrationTestHarness'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ed 'ConnectionStrings:EdFi_Security' 'Server=(LocalDB)\MSSQLLocalDB; Database=EdFi_Security; Connection Timeout=30; Trusted_Connection=True; Persist Security Info=True; Application Name=EdFi.Ods.Api.IntegrationTestHarness'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ed 'ConnectionStrings:EdFi_Master'   'Server=(LocalDB)\MSSQLLocalDB; Database=master; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.Api.IntegrationTestHarness'
-        
-        Write-Host "Starting MSSQLLocalDB"
-        SQLLocalDB start MSSQLLocalDB
-      shell: pwsh
+          choco install sql-server-2019  -y --params "'/IGNOREPENDINGREBOOT /IACCEPTSQLSERVERLICENSETERMS /Q /ACTION=install /INSTANCEID=MSSQLSERVER /INSTANCENAME=MSSQLSERVER /TCPENABLED=1 /UPDATEENABLED=FALSE /FEATURES=SQL,Tools'" --execution-timeout=$installTimeout
+          choco install sqlpackage
     - name: ODS/API InitDev, SdkGen, Integration Test, Unit Test, Package
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -75,21 +75,30 @@ jobs:
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
         .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -PackageOutput "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/NugetPackages"
       shell: pwsh
-    - name: Upload Test Reports
+    - name: Upload Unit And Integration Test Reports
       if: success() || failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
       with:
-        name: test-results
+        name: unit-test-results
         path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/
-    - name: Test Report
+    - name: Unit Test Report
       uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6
       if: success() || failure()
       with:
-        name: Integration and Unit Tests
+        name: Unit Tests
         path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/*.trx
         path-replace-backslashes: 'true'
         working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
         reporter: dotnet-trx
+    - name: Postman Test Report
+      uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6
+      if: success() || failure()
+      with:
+        name: Integration Tests
+        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/*.xml
+        path-replace-backslashes: 'true'
+        working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
+        reporter: java-junit
     - name: Upload initdev logs
       if: success() || failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -103,8 +103,8 @@ jobs:
       if: success() || failure()
       with:
         name: Integration and Unit Tests
-        artifact: 'test-results'
-        path: "*.trx"
+        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/EdFi.Ods.Repositories.NHibernate.Tests.dll.trx
+        working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
         reporter: dotnet-trx
     - name: Upload initdev logs
       if: success() || failure()

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -79,7 +79,7 @@ jobs:
       if: success() || failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
       with:
-        name: unit-test-results
+        name: test-results
         path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/
     - name: Unit Test Report
       uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -103,7 +103,8 @@ jobs:
       if: success() || failure()
       with:
         name: Integration and Unit Tests
-        path: ${{ github.workspace }}\Ed-Fi-ODS-Implementation/reports/EdFi.Ods.Repositories.NHibernate.Tests.dll.trx
+        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/EdFi.Ods.Repositories.NHibernate.Tests.dll.trx
+        path-replace-backslashes: 'true'
         working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
         reporter: dotnet-trx
     - name: Upload initdev logs

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -92,14 +92,20 @@ jobs:
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
         .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -PackageOutput "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/NugetPackages"
       shell: pwsh
+    - name: Upload Test Reports
+      if: success() || failure()
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+      with:
+        name: test-results
+        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/
     - name: Test Report
       uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6
       if: success() || failure()
       with:
         name: Integration and Unit Tests
-        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/*.trx
+        artifact: 'test-results'
+        path: "*.trx"
         reporter: dotnet-trx
-        working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
     - name: Upload initdev logs
       if: success() || failure()
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -103,7 +103,7 @@ jobs:
       if: success() || failure()
       with:
         name: Integration and Unit Tests
-        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/reports/EdFi.Ods.Repositories.NHibernate.Tests.dll.trx
+        path: ${{ github.workspace }}\Ed-Fi-ODS-Implementation/reports/EdFi.Ods.Repositories.NHibernate.Tests.dll.trx
         working-directory: ${{ github.workspace }}/Ed-Fi-ODS-Implementation
         reporter: dotnet-trx
     - name: Upload initdev logs

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -62,28 +62,11 @@ jobs:
       shell: pwsh
       run: |
            .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
-    - name: Setup Sql Server Connection String
-      working-directory: ./Ed-Fi-ODS-Implementation/
+    - name: Install sql-server-2019 & sqlpackage
+      shell: powershell
       run: |
-        $ErrorActionPreference = 'Stop'
-        $PSVersionTable
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-           
-        # EdFi.Ods.WebApi
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ec 'ConnectionStrings:EdFi_Ods'      'Server=(LocalDB)\\MSSQLLocalDB; Database=EdFi_{0}; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.WebApi;'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ec 'ConnectionStrings:EdFi_Admin'    'Server=(LocalDB)\\MSSQLLocalDB; Database=EdFi_Admin; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.WebApi;'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ec 'ConnectionStrings:EdFi_Security' 'Server=(LocalDB)\\MSSQLLocalDB; Database=EdFi_Security; Connection Timeout=30; Trusted_Connection=True; Persist Security Info=True; Application Name=EdFi.Ods.WebApi;'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ec 'ConnectionStrings:EdFi_Master'   'Server=(LocalDB)\\MSSQLLocalDB; Database=master; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.WebApi;'
-
-        # EdFi.Ods.Api.IntegrationTestHarness
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ed 'ConnectionStrings:EdFi_Ods'      'Server=(LocalDB)\MSSQLLocalDB; Database=EdFi_Ods_Populated_Template_Test; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.Api.IntegrationTestHarness'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ed 'ConnectionStrings:EdFi_Admin'    'Server=(LocalDB)\MSSQLLocalDB; Database=EdFi_Admin; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.Api.IntegrationTestHarness'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ed 'ConnectionStrings:EdFi_Security' 'Server=(LocalDB)\MSSQLLocalDB; Database=EdFi_Security; Connection Timeout=30; Trusted_Connection=True; Persist Security Info=True; Application Name=EdFi.Ods.Api.IntegrationTestHarness'
-        dotnet user-secrets set --id f1506d66-289c-44cb-a2e2-80411cc690ed 'ConnectionStrings:EdFi_Master'   'Server=(LocalDB)\MSSQLLocalDB; Database=master; Connection Timeout=30; Trusted_Connection=True; Application Name=EdFi.Ods.Api.IntegrationTestHarness'
-        
-        Write-Host "Starting MSSQLLocalDB"
-        SQLLocalDB start MSSQLLocalDB
-      shell: pwsh
+          choco install sql-server-2019  -y --params "'/IGNOREPENDINGREBOOT /IACCEPTSQLSERVERLICENSETERMS /Q /ACTION=install /INSTANCEID=MSSQLSERVER /INSTANCENAME=MSSQLSERVER /TCPENABLED=1 /UPDATEENABLED=FALSE /FEATURES=SQL,Tools'" --execution-timeout=$installTimeout
+          choco install sqlpackage
     - name: ODS/API InitDev and SdkGen
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |

--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -53,8 +53,7 @@ function Invoke-Newman {
         }
         else {
             $testFile = $collectionFile.Name -Replace ".postman_collection.json",""
-            $reportPath +=  $testFile + " postmanreport.xml"
-            newman run $collectionFile.FullName -e $script:environmentJson --disable-unicode --reporters 'junit,cli' --reporter-junit-export "$reportPath"
+            newman run $collectionFile.FullName -e $script:environmentJson --disable-unicode --reporters 'junit,cli' --reporter-junit-export "$reportPath/$testFile.xml"
         }
     }
 }

--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -28,9 +28,11 @@ $script:environmentJson = (Join-Path $script:postmanFolder "environment.json")
 
 function Install-Newman {
     try {
-        npm install -g newman@5.2.2
-        npm install -g newman-reporter-teamcity@0.1.12
-        npm install -g newman-reporter-junitfull
+        npm --version
+        node --version
+        npm install -g newman@5.2.2 --verbose
+        npm install -g newman-reporter-teamcity@0.1.12 --verbose
+        npm install -g newman-reporter-junitfull --verbose
         newman --version
     }
     catch {
@@ -50,7 +52,7 @@ function Invoke-Newman {
             newman run $collectionFile.FullName -e $script:environmentJson --suppress-exit-code --disable-unicode --reporters 'teamcity,cli'
         }
         else {
-            newman run $collectionFile.FullName -e $script:environmentJson --disable-unicode -r junit,cli --reporter-junit-export $reportPath
+            newman run $collectionFile.FullName -e $script:environmentJson --disable-unicode --reporters 'junit,cli' --reporter-junit-export $reportPath
         }
     }
 }

--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -30,6 +30,7 @@ function Install-Newman {
     try {
         npm install -g newman@5.2.2
         npm install -g newman-reporter-teamcity@0.1.12
+        npm install -g newman-reporter-junitfull
         newman --version
     }
     catch {

--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -41,6 +41,7 @@ function Install-Newman {
 function Invoke-Newman {
     $collectionFileDirectory = (Get-RepositoryResolvedPath "Postman Test Suite\")
     $collectionFiles = Get-ChildItem $collectionFileDirectory -Filter "*.postman_collection.json"
+    $reportPath = (Get-RepositoryRoot "Ed-Fi-ODS-Implementation") + "/reports/postmanreport.xml"
 
     foreach ($collectionFile in $collectionFiles) {
         Write-host $script:environmentJson
@@ -48,7 +49,7 @@ function Invoke-Newman {
             newman run $collectionFile.FullName -e $script:environmentJson --suppress-exit-code --disable-unicode --reporters 'teamcity,cli'
         }
         else {
-            newman run $collectionFile.FullName -e $script:environmentJson --disable-unicode
+            newman run $collectionFile.FullName -e $script:environmentJson --disable-unicode -r junit,cli --reporter-junit-export $reportPath
         }
     }
 }

--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -28,11 +28,9 @@ $script:environmentJson = (Join-Path $script:postmanFolder "environment.json")
 
 function Install-Newman {
     try {
-        npm --version
-        node --version
         npm install -g newman@5.2.2 --verbose
-        npm install -g newman-reporter-teamcity@0.1.12 --verbose
-        npm install -g newman-reporter-junitfull --verbose
+        npm install -g newman-reporter-teamcity@0.1.12
+        npm install -g newman-reporter-junitfull
         newman --version
     }
     catch {

--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -44,7 +44,7 @@ function Install-Newman {
 function Invoke-Newman {
     $collectionFileDirectory = (Get-RepositoryResolvedPath "Postman Test Suite\")
     $collectionFiles = Get-ChildItem $collectionFileDirectory -Filter "*.postman_collection.json"
-    $reportPath = (Get-RepositoryRoot "Ed-Fi-ODS-Implementation") + "/reports/postmanreport.xml"
+    $reportPath = (Get-RepositoryRoot "Ed-Fi-ODS-Implementation") + "/reports/"
 
     foreach ($collectionFile in $collectionFiles) {
         Write-host $script:environmentJson
@@ -52,7 +52,9 @@ function Invoke-Newman {
             newman run $collectionFile.FullName -e $script:environmentJson --suppress-exit-code --disable-unicode --reporters 'teamcity,cli'
         }
         else {
-            newman run $collectionFile.FullName -e $script:environmentJson --disable-unicode --reporters 'junit,cli' --reporter-junit-export $reportPath
+            $testFile = $collectionFile.Name -Replace ".postman_collection.json",""
+            $reportPath +=  $testFile + " postmanreport.xml"
+            newman run $collectionFile.FullName -e $script:environmentJson --disable-unicode --reporters 'junit,cli' --reporter-junit-export "$reportPath"
         }
     }
 }

--- a/logistics/scripts/run-tests.ps1
+++ b/logistics/scripts/run-tests.ps1
@@ -34,6 +34,7 @@ foreach ($assembly in $testAssemblies) {
         $reportName = $reports + (Get-ChildItem $assembly | Select-Object -ExpandProperty Name) + ".trx"
     }
 
+    Write-Host "Report for $assembly will be stored in $reportName"
     & dotnet test $assembly --logger ("trx;LogFileName=" + $reportName)
 
     Write-Host "assembly exit code: $LASTEXITCODE"

--- a/logistics/scripts/run-tests.ps1
+++ b/logistics/scripts/run-tests.ps1
@@ -34,7 +34,6 @@ foreach ($assembly in $testAssemblies) {
         $reportName = $reports + (Get-ChildItem $assembly | Select-Object -ExpandProperty Name) + ".trx"
     }
 
-    Write-Host "Report for $assembly will be stored in $reportName"
     & dotnet test $assembly --logger ("trx;LogFileName=" + $reportName)
 
     Write-Host "assembly exit code: $LASTEXITCODE"


### PR DESCRIPTION
Now the initdev builds that run unit and integration/postman tests have a test reporter step that collects the logs to report on if the tests passed or failed. 

For an example of a build with failing unit tests, there is [this build](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/runs/3292104493/jobs/5427072615) with [this report](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/runs/9015251880) showing failures

And for an example of a build with failing integration tests, there is [this build](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/runs/3299947939/jobs/5443895121) with [this report](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/runs/9037734743) showing failures

To be able to see any of the logs from a build at any time, you can go to the build, expand either of the report steps, and then expand the "create test report..." node to see the link to the check that is posted to github with the results, like so:
![image](https://user-images.githubusercontent.com/1013553/197290731-0e3622bf-f524-4e5f-ac0f-3e8ab73f3521.png)

There are also now artifacts for the builds that contain the unit and integration test logs as you can see here:

![image](https://user-images.githubusercontent.com/1013553/197292268-5c9b13f9-212c-4eb4-8e78-a466d881ad49.png)

![image](https://user-images.githubusercontent.com/1013553/197292450-a14f2ef8-110d-4da4-94fa-e1a083d0dc40.png)


The smoke tests builds did not have any steps added since in the TeamCity builds we did not have any specific reporting done for those and relied on having the exit code to determine if the smoke tests passed or fialed.

Additionally, the builds that were not already using SQL 2019 were switched to use that instead of LocalDB