### PR TITLE
ODS-5377 - Support PS 7.2 and Unix - Script group 8

### DIFF
--- a/DatabaseTemplate/Modules/create-database-template.psm1
+++ b/DatabaseTemplate/Modules/create-database-template.psm1
@@ -148,7 +148,7 @@ function Copy-SchemaFiles {
         foreach ($xsdFile in $xsdFiles) {
             $elapsed = Use-Stopwatch {
                 Write-Host "copy to $($directory.Name)/$($xsdFile.Name) " -NoNewline
-                Copy-Item -Path $xsdFile.FullName -Destination "$directory/$xsdFile"
+                Copy-Item -Path $xsdFile.FullName -Destination "$directory/$($xsdFile.Name)"
             }
             Write-Host $elapsed.duration -ForegroundColor DarkGray
         }

--- a/DatabaseTemplate/Modules/create-minimal-template.psm1
+++ b/DatabaseTemplate/Modules/create-minimal-template.psm1
@@ -48,12 +48,12 @@ function Initialize-MinimalTemplate {
         * Executes first load scenario using the bootstrap data and claimset
         * Executes second load scenario using the rest of the sample data and the sandbox claimset
         * Stops the test harness api
-        * Creates a backup of the new minimal template at: Ed-Fi-ODS-Implementation\DatabaseTemplate\Database\Minimal.Template.bak
-        * Creates a .nuspec file for the new minimal template at: Ed-Fi-ODS-Implementation\DatabaseTemplate\Database\Minimal.Template.nuspec
+        * Creates a backup of the new minimal template at: Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/Minimal.Template.bak
+        * Creates a .nuspec file for the new minimal template at: Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/Minimal.Template.nuspec
 
     .PARAMETER samplePath
-        An absolute path to the folder to load samples from, for example: C:\MySampleXmlData\.
-        Also supports specific version folders of the Data Standard repository, for example: C:\Ed-Fi-Standard\v3.0\ or C:\Ed-Fi-Standard\v2.0\
+        An absolute path to the folder to load samples from, for example: C:/MySampleXmlData/.
+        Also supports specific version folders of the Data Standard repository, for example: C:/Ed-Fi-Standard/v3.0/ or C:/Ed-Fi-Standard/v2.0/
 
     .PARAMETER noExtensions
         Ignores any extension sources when running the sql scripts against the database.
@@ -65,12 +65,12 @@ function Initialize-MinimalTemplate {
     The database engine provider, either 'SQLServer' or 'PostgreSQL'
 
     .EXAMPLE
-        PS> Initialize-MinimalTempalate -samplePath "C:\edfi\Ed-Fi-Standard\v3.2\"
+        PS> Initialize-MinimalTempalate -samplePath "C:/edfi/Ed-Fi-Standard/v3.2/"
     #>
     param(
         [Parameter(
             Mandatory = $true,
-            HelpMessage = "An absolute path to the folder to load samples from, for example: C:\MySampleXmlData\.`r`nAlso supports specific version folders of the Data Standard repository, for example: C:\Ed-Fi-Standard\v3.0\ or C:\Ed-Fi-Standard\v2.0\"
+            HelpMessage = "An absolute path to the folder to load samples from, for example: C:/MySampleXmlData/.`r`nAlso supports specific version folders of the Data Standard repository, for example: C:/Ed-Fi-Standard/v3.0/ or C:/Ed-Fi-Standard/v2.0/"
         )]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( { Resolve-Path $_ } )]

--- a/DatabaseTemplate/Modules/create-populated-template.psm1
+++ b/DatabaseTemplate/Modules/create-populated-template.psm1
@@ -6,8 +6,8 @@
 
 $ErrorActionPreference = "Stop"
 
-& "$PSScriptRoot\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate\Modules\create-database-template.psm1")
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/create-database-template.psm1")
 
 function Get-PopulatedConfiguration([hashtable] $config = @{ }) {
 
@@ -42,12 +42,12 @@ function Initialize-PopulatedTemplate {
         * Executes first load scenario using the bootstrap data and claimset
         * Executes second load scenario using the rest of the sample data and the sandbox claimset
         * Stops the test harness api
-        * Creates a backup of the new populated template at: Ed-Fi-ODS-Implementation\DatabaseTemplate\Database\Populated.Template.bak
-        * Creates a .nuspec file for the new populated template at: Ed-Fi-ODS-Implementation\DatabaseTemplate\Database\Populated.Template.nuspec
+        * Creates a backup of the new populated template at: Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/Populated.Template.bak
+        * Creates a .nuspec file for the new populated template at: Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/Populated.Template.nuspec
 
     .PARAMETER samplePath
-        An absolute path to the folder to load samples from, for example: C:\MySampleXmlData\.
-        Also supports specific version folders of the Data Standard repository, for example: C:\Ed-Fi-Standard\v3.0\ or C:\Ed-Fi-Standard\v2.0\
+        An absolute path to the folder to load samples from, for example: C:/MySampleXmlData/.
+        Also supports specific version folders of the Data Standard repository, for example: C:/Ed-Fi-Standard/v3.0/ or C:/Ed-Fi-Standard/v2.0/
 
     .PARAMETER noExtensions
         Ignores any extension sources when running the sql scripts against the database.
@@ -59,12 +59,12 @@ function Initialize-PopulatedTemplate {
     The database engine provider, either 'SQLServer' or 'PostgreSQL'
 
     .EXAMPLE
-        PS> Initialize-PopulatedTempalate -samplePath "C:\edfi\Ed-Fi-Standard\v3.2\"
+        PS> Initialize-PopulatedTempalate -samplePath "C:/edfi/Ed-Fi-Standard/v3.2/"
     #>
     param(
         [Parameter(
             Mandatory = $true,
-            HelpMessage = "An absolute path to the folder to load samples from, for example: C:\MySampleXmlData\.`r`nAlso supports specific version folders of the Data Standard repository, for example: C:\Ed-Fi-Standard\v3.0\ or C:\Ed-Fi-Standard\v2.0\"
+            HelpMessage = "An absolute path to the folder to load samples from, for example: C:/MySampleXmlData/.`r`nAlso supports specific version folders of the Data Standard repository, for example: C:/Ed-Fi-Standard/v3.0/ or C:/Ed-Fi-Standard/v2.0/"
         )]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( { Resolve-Path $_ } )]

--- a/DatabaseTemplate/Modules/create-tpdm-minimal-template.psm1
+++ b/DatabaseTemplate/Modules/create-tpdm-minimal-template.psm1
@@ -6,8 +6,8 @@
 
 $ErrorActionPreference = "Stop"
 
-& "$PSScriptRoot\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate\Modules\create-database-template.psm1")
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/create-database-template.psm1")
 
 function Get-TPDMMinimalConfiguration([hashtable] $config = @{ }) {
 
@@ -19,14 +19,14 @@ function Get-TPDMMinimalConfiguration([hashtable] $config = @{ }) {
     $config.Remove('apiClientNameSandbox')
 
     $config.testHarnessJsonConfigLEAs = @()
-    $config.testHarnessJsonConfig = "$PSScriptRoot\testHarnessConfiguration.TPDM.json"
+    $config.testHarnessJsonConfig = "$PSScriptRoot/testHarnessConfiguration.TPDM.json"
 
     $config.Remove('bulkLoadTempDirectorySample')
     $config.bulkLoadBootstrapInterchanges = @("InterchangeDescriptors")
     $config.bulkLoadMaxRequests = 1
     $config.schemaDirectories = @(
-        (Get-RepositoryResolvedPath "Application\EdFi.Ods.Standard\Artifacts\Schemas\")
-        ("$(Get-PluginFolderFromSettings $config.appSettings)\EdFi.Suite3.Ods.Extensions.TPDM*\Artifacts\Schemas\")
+        (Get-RepositoryResolvedPath "Application/EdFi.Ods.Standard/Artifacts/Schemas/")
+        ("$(Get-PluginFolderFromSettings $config.appSettings)/EdFi.Suite3.Ods.Extensions.TPDM*/Artifacts/Schemas/")
     )
 
     $config.databaseBackupName = "EdFi.Ods.Minimal.Template.TPDM.Core"
@@ -58,12 +58,12 @@ function Initialize-TPDMMinimalTemplate {
         * Executes first load scenario using the bootstrap data and claimset
         * Executes second load scenario using the rest of the sample data and the sandbox claimset
         * Stops the test harness api
-        * Creates a backup of the new minimal template at: Ed-Fi-ODS-Implementation\DatabaseTemplate\Database\Minimal.Template.bak
-        * Creates a .nuspec file for the new minimal template at: Ed-Fi-ODS-Implementation\DatabaseTemplate\Database\Minimal.Template.nuspec
+        * Creates a backup of the new minimal template at: Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/Minimal.Template.bak
+        * Creates a .nuspec file for the new minimal template at: Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/Minimal.Template.nuspec
 
     .PARAMETER samplePath
-        An absolute path to the folder to load samples from, for example: C:\MySampleXmlData\.
-        Also supports specific version folders of the Data Standard repository, for example: C:\Ed-Fi-Standard\v3.0\ or C:\Ed-Fi-Standard\v2.0\
+        An absolute path to the folder to load samples from, for example: C:/MySampleXmlData/.
+        Also supports specific version folders of the Data Standard repository, for example: C:/Ed-Fi-Standard/v3.0/ or C:/Ed-Fi-Standard/v2.0/
 
     .PARAMETER noExtensions
         Ignores any extension sources when running the sql scripts against the database.
@@ -75,12 +75,12 @@ function Initialize-TPDMMinimalTemplate {
     The database engine provider, either 'SQLServer' or 'PostgreSQL'
 
     .EXAMPLE
-        PS> Initialize-TPDMMinimalTemplate -samplePath "C:\edfi\Ed-Fi-Standard\v3.2\"
+        PS> Initialize-TPDMMinimalTemplate -samplePath "C:/edfi/Ed-Fi-Standard/v3.2/"
     #>
     param(
         [Parameter(
             Mandatory = $false,
-            HelpMessage = "An absolute path to the folder to load samples from, for example: C:\MySampleXmlData\.`r`nAlso supports specific version folders of the Data Standard repository, for example: C:\Ed-Fi-Standard\v3.0\ or C:\Ed-Fi-Standard\v2.0\"
+            HelpMessage = "An absolute path to the folder to load samples from, for example: C:/MySampleXmlData/.`r`nAlso supports specific version folders of the Data Standard repository, for example: C:/Ed-Fi-Standard/v3.0/ or C:/Ed-Fi-Standard/v2.0/"
         )]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( { Resolve-Path $_ } )]

--- a/DatabaseTemplate/Modules/create-tpdm-template.psm1
+++ b/DatabaseTemplate/Modules/create-tpdm-template.psm1
@@ -6,8 +6,8 @@
 
 $ErrorActionPreference = "Stop"
 
-& "$PSScriptRoot\..\..\logistics\scripts\modules\load-path-resolver.ps1"
-Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate\Modules\create-database-template.psm1")
+& "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate/Modules/create-database-template.psm1")
 
 function Get-TPDMConfiguration([hashtable] $config = @{ }) {
 
@@ -17,12 +17,12 @@ function Get-TPDMConfiguration([hashtable] $config = @{ }) {
     $config.appSettings = Merge-Hashtables $config.appSettings, (Get-DefaultTemplateSettingsByEngine)[$config.engine]
 
     $config.testHarnessJsonConfigLEAs = @(255901, 1, 2, 3, 4, 5, 6, 7, 6000203)
-    $config.testHarnessJsonConfig = "$PSScriptRoot\testHarnessConfiguration.TPDM.json"
+    $config.testHarnessJsonConfig = "$PSScriptRoot/testHarnessConfiguration.TPDM.json"
 
     $config.bulkLoadMaxRequests = 1
     $config.schemaDirectories = @(
-        (Get-RepositoryResolvedPath "Application\EdFi.Ods.Standard\Artifacts\Schemas\")
-        ("$(Get-PluginFolderFromSettings $config.appSettings)\EdFi.Suite3.Ods.Extensions.TPDM*\Artifacts\Schemas\")
+        (Get-RepositoryResolvedPath "Application/EdFi.Ods.Standard/Artifacts/Schemas/")
+        ("$(Get-PluginFolderFromSettings $config.appSettings)/EdFi.Suite3.Ods.Extensions.TPDM*/Artifacts/Schemas/")
     )
 
     $config.databaseBackupName = "EdFi.Ods.Populated.Template.TPDM.Core"
@@ -54,12 +54,12 @@ function Initialize-TPDMTemplate {
         * Executes first load scenario using the bootstrap data and claimset
         * Executes second load scenario using the rest of the sample data and the sandbox claimset
         * Stops the test harness api
-        * Creates a backup of the new populated template at: Ed-Fi-ODS-Implementation\DatabaseTemplate\Database\Populated.Template.bak
-        * Creates a .nuspec file for the new populated template at: Ed-Fi-ODS-Implementation\DatabaseTemplate\Database\Populated.Template.nuspec
+        * Creates a backup of the new populated template at: Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/Populated.Template.bak
+        * Creates a .nuspec file for the new populated template at: Ed-Fi-ODS-Implementation/DatabaseTemplate/Database/Populated.Template.nuspec
 
     .PARAMETER samplePath
-        An absolute path to the folder to load samples from, for example: C:\MySampleXmlData\.
-        Also supports specific version folders of the Data Standard repository, for example: C:\Ed-Fi-Standard\v3.0\ or C:\Ed-Fi-Standard\v2.0\
+        An absolute path to the folder to load samples from, for example: C:/MySampleXmlData/.
+        Also supports specific version folders of the Data Standard repository, for example: C:/Ed-Fi-Standard/v3.0/ or C:/Ed-Fi-Standard/v2.0/
 
     .PARAMETER noExtensions
         Ignores any extension sources when running the sql scripts against the database.
@@ -71,12 +71,12 @@ function Initialize-TPDMTemplate {
     The database engine provider, either 'SQLServer' or 'PostgreSQL'
 
     .EXAMPLE
-        PS> Initialize-PopulatedTempalate -samplePath "C:\edfi\Ed-Fi-Standard\v3.2\"
+        PS> Initialize-PopulatedTempalate -samplePath "C:/edfi/Ed-Fi-Standard/v3.2/"
     #>
     param(
         [Parameter(
             Mandatory = $false,
-            HelpMessage = "An absolute path to the folder to load samples from, for example: C:\MySampleXmlData\.`r`nAlso supports specific version folders of the Data Standard repository, for example: C:\Ed-Fi-Standard\v3.0\ or C:\Ed-Fi-Standard\v2.0\"
+            HelpMessage = "An absolute path to the folder to load samples from, for example: C:/MySampleXmlData/.`r`nAlso supports specific version folders of the Data Standard repository, for example: C:/Ed-Fi-Standard/v3.0/ or C:/Ed-Fi-Standard/v2.0/"
         )]
         [ValidateNotNullOrEmpty()]
         [ValidateScript( { Resolve-Path $_ } )]


### PR DESCRIPTION
This mostly consisted of updating paths to use / instead of \ and fixing one Copy-Item call to use `.Name` to ensure only the name was pulled, since in PS it pulled just the filename but in PWSH it pulled the full name with path.

After these changes, using the modules in PWSH in both Unix and Windows worked.