### PR TITLE
[ODS-5379] Support PS 7.2 and Unix - Script group 10

### DIFF
--- a/DatabaseTemplate/Modules/create-database-template.psm1
+++ b/DatabaseTemplate/Modules/create-database-template.psm1
@@ -20,6 +20,7 @@ Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/script
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/TestHarness.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/hashtable.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/utility/xml-validation.psm1')
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/utility/cross-platform.psm1")
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'Scripts/NuGet/EdFi.RestApi.Databases/Deployment.psm1')
 
 function Get-DefaultTemplateConfiguration([hashtable] $config = @{ }) {
@@ -47,13 +48,13 @@ function Get-DefaultTemplateConfiguration([hashtable] $config = @{ }) {
     $config.apiClientNameSandbox = "BulkLoadClientSandbox"
     $config.apiYear = (Get-Date).Year
 
-    $integrationTestHarnessExecutableFileName = If (Get-IsWindows) {"EdFi.Ods.Api.IntegrationTestHarness.exe"} Else {"EdFi.Ods.Api.IntegrationTestHarness"}
+    $integrationTestHarnessExecutableFileName = "EdFi.Ods.Api.IntegrationTestHarness$(GetExeExtension)"
     $config.testHarnessExecutable = "$($config.outputFolder)/$integrationTestHarnessExecutableFileName"
     $config.testHarnessJsonConfig = "$PSScriptRoot/testHarnessConfiguration.json"
     $config.testHarnessJsonConfigLEAs = @(255901)
 
     $config.loadToolsSolution = (Get-RepositoryResolvedPath "Utilities/DataLoading/LoadTools.sln")
-    $bulkLoadClientExecutableFileName = If (Get-IsWindows) {"EdFi.BulkLoadClient.Console.exe"} Else {"EdFi.BulkLoadClient.Console"}
+    $bulkLoadClientExecutableFileName = "EdFi.BulkLoadClient.Console$(GetExeExtension)"
     $config.bulkLoadClientExecutable = "$(Get-RepositoryResolvedPath "Utilities/DataLoading/EdFi.BulkLoadClient.Console")/bin/**/$bulkLoadClientExecutableFileName"
     $config.bulkLoadBootstrapInterchanges = @("InterchangeDescriptors", "InterchangeStandards", "InterchangeEducationOrganization")
     $config.bulkLoadDirectoryMetadata = (Get-RepositoryResolvedPath "Application/EdFi.Ods.Standard/Artifacts/Metadata/")

--- a/Initialize-PowershellForDevelopment.ps1
+++ b/Initialize-PowershellForDevelopment.ps1
@@ -5,9 +5,9 @@
 
 #Requires -Version 5.0
 
-Import-Module -Force -Scope Global "$PSScriptRoot\logistics\scripts\modules\path-resolver.psm1"
-Import-Module -Force -Scope Global "$PSScriptRoot\logistics\scripts\modules\utility\cross-platform.psm1"
-$global:SolutionScriptsDir = Resolve-Path "$PSScriptRoot\Application\SolutionScripts"
+Import-Module -Force -Scope Global "$PSScriptRoot/logistics/scripts/modules/path-resolver.psm1"
+Import-Module -Force -Scope Global "$PSScriptRoot/logistics/scripts/modules/utility/cross-platform.psm1"
+$global:SolutionScriptsDir = Resolve-Path "$PSScriptRoot/Application/SolutionScripts"
 
 function Find-BlockedFiles {
     if (!(Get-IsWindows)) {
@@ -18,7 +18,7 @@ function Find-BlockedFiles {
     }
 
     ForEach ($repository in Get-RepositoryNames) {
-        $zoneIdentifierFiles = Get-ChildItem -Path $PSScriptRoot\..\$repository -recurse -Include *.ps1, *.psm1 |
+        $zoneIdentifierFiles = Get-ChildItem -Path $PSScriptRoot/../$repository -recurse -Include *.ps1, *.psm1 |
             Select-Object -Expand FullName | Get-Item -Stream "Zone.Identifier" -ErrorAction SilentlyContinue |
             Select-Object -ExpandProperty FileName |
             ForEach-Object { $_ + ":Zone.Identifier" }

--- a/Scripts/NuGet/EdFi.RestApi.Databases/PostDeploy.ps1
+++ b/Scripts/NuGet/EdFi.RestApi.Databases/PostDeploy.ps1
@@ -52,7 +52,5 @@ Add-Parameter $deploymentParams 'ExcludedExtensionSources' $ExcludedExtensionSou
 Add-Parameter $deploymentParams 'EnabledFeatureNames' $EnabledFeatureNames
 if ([Boolean]::TryParse((Add-Parameter $deploymentParams 'UsePlugins' $UsePlugins).UsePlugins, [ref]$UsePlugins)) { $deploymentParams.UsePlugins = $UsePlugins }
 
-If (-Not(Get-IsWindows)) {Add-Parameter $deploymentParams 'Engine' "PostgreSQL"} 
-
 Import-Module -Force -Scope Global "$PSScriptRoot/Deployment.psm1"
 Initialize-DeploymentEnvironment @deploymentParams

--- a/Scripts/NuGet/EdFi.RestApi.Databases/prep-package.ps1
+++ b/Scripts/NuGet/EdFi.RestApi.Databases/prep-package.ps1
@@ -96,7 +96,7 @@ $nonrepoNuspecFiles = Get-ChildItem $outputDirectory -Exclude *.nuspec, prep-pac
 
 Add-FileToNuspec -nuspecPath $nuspecPath -sourceTargetPair $nonrepoNuspecFiles
 
-Add-FileToNuspec -nuspecPath $nuspecPath -sourceTargetPair  @{ source = Select-CumulativeRepositoryResolvedItems @(If (Get-IsWindows) { "tools/EdFi.Db.Deploy.exe" } Else { "tools/EdFi.Db.Deploy" }) ; target = "tools" }
+Add-FileToNuspec -nuspecPath $nuspecPath -sourceTargetPair  @{ source = Select-CumulativeRepositoryResolvedItems "tools/EdFi.Db.Deploy$(GetExeExtension)"; target = "tools" }
 
 $dbDeployToolfiles = @(((Select-CumulativeRepositoryResolvedItems -recurse "tools/.store/edfi.suite3.db.deploy" ) |  Where-Object { -not $_.Name.EndsWith(".nupkg")} ))
 

--- a/logistics/scripts/run-smoke-tests.ps1
+++ b/logistics/scripts/run-smoke-tests.ps1
@@ -60,6 +60,7 @@ $ErrorActionPreference = 'Stop'
 $error.Clear()
 
 & "$PSScriptRoot/../../logistics/scripts/modules/load-path-resolver.ps1"
+Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/utility/cross-platform.psm1")
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath 'logistics/scripts/modules/LoadTools.psm1')
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/TestHarness.psm1")
 Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "logistics/scripts/modules/tasks/TaskHelper.psm1")
@@ -69,7 +70,7 @@ if ([string]::IsNullOrWhiteSpace($key)) { $key = Get-RandomString }
 if ([string]::IsNullOrWhiteSpace($secret)) { $secret = Get-RandomString }
 
 if ([string]::IsNullOrWhiteSpace($smokeTestExe) -or -not (Test-Path $smokeTestExe)) {
-    $smokeTestExeFileName = If (Get-IsWindows) {"EdFi.SmokeTest.Console.exe"} Else {"EdFi.SmokeTest.Console"}
+    $smokeTestExeFileName = "EdFi.SmokeTest.Console$(GetExeExtension)"
     $smokeTestExe = "$(Get-RepositoryResolvedPath "Utilities/DataLoading/EdFi.SmokeTest.Console")/bin/**/$smokeTestExeFileName"
 }
 else { $noRebuild = $true }


### PR DESCRIPTION
Note that the next modified scripts don't belong to this group:
- create-database-template.psm1
- prep-package.ps1
- run-smoke-tests.ps1

... I modified them to call `GetExeExtension` instead of `Get-IsWindows` since it's a bit more readable.