### PR TITLE
ODS-5636 - Ensure Initdev builds run on release and use correct version

### DIFF
--- a/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -24,6 +24,7 @@ env:
   REF_NAME:  ${{ GITHUB.REF_NAME }}
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
+  msbuild.buildConfiguration: "release"
 
 jobs:
   build:

--- a/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
+++ b/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
@@ -22,6 +22,7 @@ env:
   REF_NAME:  ${{ GITHUB.REF_NAME }}
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
+  msbuild.buildConfiguration: "release"
 
 jobs:
   build:

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -66,6 +66,15 @@ jobs:
       run: |
           choco install sql-server-2019  -y --params "'/IGNOREPENDINGREBOOT /IACCEPTSQLSERVERLICENSETERMS /Q /ACTION=install /INSTANCEID=MSSQLSERVER /INSTANCENAME=MSSQLSERVER /TCPENABLED=1 /UPDATEENABLED=FALSE /FEATURES=SQL,Tools'" --execution-timeout=$installTimeout
           choco install sqlpackage
+    - name: Update build.props
+      working-directory: ./Ed-Fi-ODS/
+      run: |
+        $confPath = . $env:GITHUB_WORKSPACE/Ed-Fi-ODS/Application/Directory.Build.props
+        [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
+        (Get-Content $confPath).Replace("<AssemblyVersion>1.0.0</AssemblyVersion>","<AssemblyVersion>$version</AssemblyVersion>") | Set-Content $confPath
+        (Get-Content $confPath).Replace("<FileVersion>1.0.0</FileVersion>","<FileVersion>$version</FileVersion>") | Set-Content $confPath
+        (Get-Content $confPath).Replace("<InformationalVersion>1.0.0</InformationalVersion>","<FileVersion>${{ env.VERSION_MAJOR}}.${{ env.VERSION_MINOR}}</FileVersion>") | Set-Content $confPath
+      shell: pwsh
     - name: ODS/API InitDev, SdkGen,Run Integration Tests,Run Unit Tests, Package
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -27,6 +27,7 @@ env:
   REF_NAME:  ${{ GITHUB.REF_NAME }}
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
+  msbuild.buildConfiguration: "release"
 
 jobs:
   build:

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -29,6 +29,7 @@ env:
   REF_NAME:  ${{ GITHUB.REF_NAME }}
   REPOSITORY_DISPATCH_BRANCH: ${{ github.event.client_payload.branch }}
   EDFI_SUITE_NUMBER: "Suite3"
+  msbuild.buildConfiguration: "release"
 
 jobs:
   build:


### PR DESCRIPTION
In the previously TeamCity builds we used a build feature to update Directory.build.props with an updated File/Assembly/Informational version, which was missing here, so all resulting dll's ended up being stamped as version 1.0.0.0.

Additionally, the initdev scripts rely on an environment variable for knowing if its debug or release, so now we are setting it to ensure all builds will run on release.