### PR TITLE
[ODS-5381] Ensure that all PowerShell scripts use forward slashes as directory separator

### DIFF
--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/Install-EdFiOdsSandboxAdmin.psm1
@@ -45,7 +45,7 @@ function Install-EdFiOdsSandboxAdmin {
     .EXAMPLE
         PS c:/> $parameters = @{
             PackageVersion     = '5.1.0'
-            WebSitePath        = 'c:/inetpub/Ed-Fi'
+            WebSitePath        = 'c:\inetpub\Ed-Fi'
             WebSitePort        = 8765
             WebApplicationPath = 'SandboxAdmin'
             WebApplicationName = 'SandboxAdmin5.1.0'
@@ -111,9 +111,9 @@ function Install-EdFiOdsSandboxAdmin {
         [string]
         $DownloadPath = "$PSScriptRoot/downloads",
 
-        # Path for the IIS WebSite. Default: c:/inetpub/Ed-Fi.
+        # Path for the IIS WebSite. Default: c:\inetpub\Ed-Fi.
         [string]
-        $WebSitePath = "c:/inetpub/Ed-Fi", # NB: _must_ use backslash with IIS settings
+        $WebSitePath = "c:\inetpub\Ed-Fi", # NB: _must_ use backslash with IIS settings
 
         # Web site name. Default: "Ed-Fi".
         $WebsiteName = "Ed-Fi",
@@ -437,9 +437,9 @@ function Uninstall-EdFiOdsSandboxAdmin {
         [string]
         $ToolsPath = "$PSScriptRoot/tools",
 
-        # Path for the web application. Default: "c:/inetpub/Ed-Fi/SandboxAdmin".
+        # Path for the web application. Default: "c:\inetpub\Ed-Fi\SandboxAdmin".
         [string]
-        $WebApplicationPath = "c:/inetpub/Ed-Fi/SandboxAdmin",
+        $WebApplicationPath = "c:\inetpub\Ed-Fi\SandboxAdmin",
 
         # Web application name. Default: "SandboxAdmin".
         [string]

--- a/Scripts/NuGet/EdFi.Installer.SandboxAdmin/test.ps1
+++ b/Scripts/NuGet/EdFi.Installer.SandboxAdmin/test.ps1
@@ -33,9 +33,9 @@ function Invoke-InstallCustomSettings {
     # this should match the example for the Install-EdFiOdsSandboxAdmin function in Install-EdFiOdsSandboxAdmin.psm1
     $parameters = @{
         PackageVersion     = '5.1.0'
-        WebSitePath        = 'c:/inetpub/SandboxAdmin'
+        WebSitePath        = 'c:\inetpub\SandboxAdmin'
         WebSitePort        = 8765
-        WebApplicationPath = 'c:/inetpub/SandboxAdmin/5.1.0'
+        WebApplicationPath = 'c:\inetpub\SandboxAdmin\5.1.0'
         WebApplicationName = 'SandboxAdmin5.1.0'
         Settings           = @{
             ConnectionStrings            = @{
@@ -80,7 +80,7 @@ function Invoke-Uninstall { UnInstall-EdFiOdsSandboxAdmin }
 
 function Invoke-UninstallCustomSettings {
     $parameters = @{
-        WebApplicationPath = "c:/inetpub/SandboxAdmin/5.1.0"
+        WebApplicationPath = "c:\inetpub\SandboxAdmin\5.1.0"
         WebApplicationName = "SandboxAdmin"
     }
 

--- a/Scripts/NuGet/EdFi.Installer.SwaggerUI/Install-EdFiOdsSwaggerUI.psm1
+++ b/Scripts/NuGet/EdFi.Installer.SwaggerUI/Install-EdFiOdsSwaggerUI.psm1
@@ -38,7 +38,7 @@ function Install-EdFiOdsSwaggerUI {
             ToolsPath = "C:/temp/tools"
             WebApiMetadataUrl = "https://my-server.example/EdFiOdsWebApi/metadata"
             WebApiVersionUrl = "https://my-server.example/EdFiOdsWebApi"
-            WebSitePath="c:/inetpub/Ed-Fi"
+            WebSitePath="c:\inetpub\Ed-Fi"
             WebApplicationPath="SwaggerUI"
         }
         PS c:/> Install-EdFiOdsSwaggerUI @parameters
@@ -65,9 +65,9 @@ function Install-EdFiOdsSwaggerUI {
         [string]
         $DownloadPath = "$PSScriptRoot/downloads",
 
-        # Path for the IIS WebSite. Default: c:/inetpub/Ed-Fi.
+        # Path for the IIS WebSite. Default: c:\inetpub\Ed-Fi.
         [string]
-        $WebSitePath = "c:/inetpub/Ed-Fi", # NB: _must_ use backslash with IIS settings
+        $WebSitePath = "c:\inetpub\Ed-Fi", # NB: _must_ use backslash with IIS settings
 
         # Web site name. Default: "Ed-Fi".
         [string]
@@ -186,9 +186,9 @@ function Uninstall-EdFiOdsSwaggerUI {
         [string]
         $ToolsPath = "$PSScriptRoot/tools",
 
-        # Path for the web application. Default: "c:/inetpub/Ed-Fi/SwaggerUI".
+        # Path for the web application. Default: "c:\inetpub\Ed-Fi\SwaggerUI".
         [string]
-        $WebApplicationPath = "c:/inetpub/Ed-Fi/SwaggerUI",
+        $WebApplicationPath = "c:\inetpub\Ed-Fi\SwaggerUI",
 
         # Web application name. Default: "SwaggerUI".
         [string]

--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -51,8 +51,8 @@ function Install-EdFiOdsWebApi {
 
         Use all available default values, connecting to databases on a single SQL Server instance.
         Connect to the database with integrated security. The WebApi application will be set to
-        Shared Instance mode. This will create IIS website "Ed-Fi" with root c:/inetpub/Ed-Fi,
-        and the application files will be in "c:/inetpub/Ed-Fi/WebApi". Installs the most recent full
+        Shared Instance mode. This will create IIS website "Ed-Fi" with root c:\inetpub\Ed-Fi,
+        and the application files will be in "c:\inetpub\Ed-Fi\WebApi". Installs the most recent full
         release of the WebApi software.
     .EXAMPLE
         PS c:/> $parameters = @{
@@ -88,7 +88,7 @@ function Install-EdFiOdsWebApi {
                 Username="ods-admin"
             }
             WebSiteName="Ed-Fi-3"
-            WebSitePath="c:/inetpub/Ed-Fi"
+            WebSitePath="c:\inetpub\Ed-Fi"
             WebApplicationPath="EdFiOdsApi"
             WebSitePort=843
             CertThumbprint="a909502dd82ae41433e6f83886b00d4277a32a7b"
@@ -171,9 +171,9 @@ function Install-EdFiOdsWebApi {
         [string]
         $DownloadPath = "$PSScriptRoot/downloads",
 
-        # Path for the IIS WebSite. Default: c:/inetpub/Ed-Fi.
+        # Path for the IIS WebSite. Default: c:\inetpub\Ed-Fi.
         [string]
-        $WebSitePath = "c:/inetpub/Ed-Fi", # NB: _must_ use backslash with IIS settings
+        $WebSitePath = "c:\inetpub\Ed-Fi", # NB: _must_ use backslash with IIS settings
 
         # Web site name. Default: "Ed-Fi".
         [string]
@@ -601,9 +601,9 @@ function Uninstall-EdFiOdsWebApi {
         [string]
         $ToolsPath = "$PSScriptroot/tools",
 
-        # Path for the web application. Default: "c:/inetpub/Ed-Fi/WebApi".
+        # Path for the web application. Default: "c:\inetpub\Ed-Fi\WebApi".
         [string]
-        $WebApplicationPath = "c:/inetpub/Ed-Fi/WebApi",
+        $WebApplicationPath = "c:\inetpub\Ed-Fi\WebApi",
 
         # Web application name. Default: "WebApi".
         [string]

--- a/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/test.ps1
@@ -21,9 +21,9 @@ function Invoke-DifferentWebSite {
             UseIntegratedSecurity=$true
         }
         WebSiteName = "DifferentWebSite"
-        WebSitePath = "c:/inetpub/DifferentWebSite"
+        WebSitePath = "c:\inetpub\DifferentWebSite"
         WebSitePort = 444
-        WebApplicationPath = "c:/inetpub/DifferentWebSite/DifferentAppPath"
+        WebApplicationPath = "c:\inetpub\DifferentWebSite\DifferentAppPath"
         WebApplicationName = "SomethingElse"
     }
     Install-EdFiOdsWebApi @p
@@ -160,7 +160,7 @@ function Invoke-FeatureOverride {
 function Invoke-Uninstall {
     $p = @{
         ToolsPath = "../../../tools"
-        WebApplicationPath = "c:/inetpub/Ed-Fi/WebApi"
+        WebApplicationPath = "c:\inetpub\Ed-Fi\WebApi"
         WebApplicationName = "WebApi"
         WebSiteName = "Ed-Fi"        
     }
@@ -171,7 +171,7 @@ function Invoke-UninstallDifferentWebSite {
     $p = @{
         WebApplicationName = "SomethingElse"
         WebSiteName = "DifferentWebSite"
-        WebApplicationPath = "c:/inetpub/DifferentWebSite/DifferentAppPath"
+        WebApplicationPath = "c:\inetpub\DifferentWebSite\DifferentAppPath"
     }
     Uninstall-EdFiOdsWebApi @p
 }


### PR DESCRIPTION
IIS management only accepts paths that use backslash as directory separator, so I'm reverting a few changes that were made in https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/pull/548. 