### PR TITLE
ODS-5643 - Update Glendale and Northridge to 6.0 and allow for Postgres restoring

### DIFF
--- a/DatabaseTemplate/Scripts/Glendale.ps1
+++ b/DatabaseTemplate/Scripts/Glendale.ps1
@@ -4,8 +4,8 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 $params = @{
-    sourceUrl = "https://odsassets.blob.core.windows.net/public/Glendale/EdFi_Ods_Glendale_v53_20220120.7z"
-    fileName  = "EdFi_Ods_Glendale_v53_20220120.7z"
+    sourceUrl = "https://odsassets.blob.core.windows.net/public/Glendale/EdFi_Ods_Glendale_v60_20220930.7z"
+    fileName  = "EdFi_Ods_Glendale_v60_20220930.7z"
 }
 
 return (& "$PSScriptRoot/../Modules/get-template-from-web.ps1" @params)

--- a/DatabaseTemplate/Scripts/Northridge.ps1
+++ b/DatabaseTemplate/Scripts/Northridge.ps1
@@ -4,8 +4,8 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 $params = @{
-    sourceUrl = "https://odsassets.blob.core.windows.net/public/Northridge/EdFi_Ods_Northridge_v53_20220120.7z"
-    fileName  = "EdFi_Ods_Northridge_v53_20220120.7z"
+    sourceUrl = "https://odsassets.blob.core.windows.net/public/Northridge/EdFi_Ods_Northridge_v60_20220930.7z"
+    fileName  = "EdFi_Ods_Northridge_v60_20220930.7z"
 }
 
 return (& "$PSScriptRoot/../Modules/get-template-from-web.ps1" @params)

--- a/logistics/scripts/modules/database/database-lifecycle.psm1
+++ b/logistics/scripts/modules/database/database-lifecycle.psm1
@@ -249,8 +249,8 @@ function Get-PostgreSQLDatabaseCreateStrategy {
     }
     $databaseExists = (Test-PostgreSQLDatabaseExists @params)
 
-    if (-not $databaseExists -and $createByRestoringBackup) {
-        Install-PostgreSQLTemplate @params -backupFile $createByRestoringBackup
+    if (-not $databaseExists -and $CreateByRestoringBackup) {
+        Install-PostgreSQLTemplate @params -backupFile $CreateByRestoringBackup
     }
 }
 


### PR DESCRIPTION
The links for restoring Glendale and Northridge have now been updated to ODS 6.0 backups for SQL Server. Additionally, initdev workflow was tested with the Postgres backups and issues were found where it did not work so code changes were made to get them to work. Now both versions should be able to be restored successfully and have the API/Sandbox run against them.

One thing to note if running with these larger datasets and you try to create a new database via Sandbox Admin, it will take some time to create a new database since these datasets are much larger. There is also a known issue where there are less students seen in the database in Postgres, and we have created ODS-5666 to address this.