### PR TITLE
[ODS-5675] Include basic Request-Response details in the logs

### DIFF
--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/log4net.config
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/log4net.config
@@ -29,4 +29,18 @@
     <appender-ref ref="RollingFile" />
     <appender-ref ref="DebugAppender" />
   </root>
+  <logger name="RequestResponseDetailsLogger" additivity="false">
+    <level value="ERROR" />
+    <appender-ref ref="RequestResponseDetailsFileAppender" />
+  </logger>
+  <appender name="RequestResponseDetailsFileAppender" type="log4net.Appender.RollingFileAppender">
+    <threshold value="ERROR" />
+    <file value="${TEST_HARNESS_LOG_NAME_PREFIX}TestHarnessRequestResponseDetailsLog.log"/>
+    <appendToFile value="false"/>
+    <maximumFileSize value="5MB" />
+    <maxSizeRollBackups value="10" />
+    <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5level %n ClientId: %property{ApiClientId} %n %message %n %exception" />
+    </layout>
+  </appender>
 </log4net>

--- a/Application/EdFi.Ods.WebApi/log4net.config
+++ b/Application/EdFi.Ods.WebApi/log4net.config
@@ -37,4 +37,18 @@
     <appender-ref ref="TraceAppender" />
     <appender-ref ref="AppInsightsAppender" />
   </root>
+  <logger name="RequestResponseDetailsLogger" additivity="false">
+    <level value="ERROR" />
+    <appender-ref ref="RequestResponseDetailsFileAppender" />
+  </logger>
+  <appender name="RequestResponseDetailsFileAppender" type="log4net.Appender.RollingFileAppender">
+    <threshold value="ERROR" />
+    <file value="WebApiRequestResponseDetailsLog.log"/>
+    <appendToFile value="true"/>
+    <maximumFileSize value="100KB" />
+    <maxSizeRollBackups value="7" />
+    <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5level %n ClientId: %property{ApiClientId} %n %message %n %exception" />
+    </layout>
+  </appender>
 </log4net>

--- a/Application/EdFi.Ods.WebApi/log4net.development.config
+++ b/Application/EdFi.Ods.WebApi/log4net.development.config
@@ -33,4 +33,16 @@
     <appender-ref ref="FileAppender" />
     <appender-ref ref="TraceAppender" />
   </root>
+  <logger name="RequestResponseDetailsLogger" additivity="false">
+    <level value="ERROR" />
+    <appender-ref ref="RequestResponseDetailsFileAppender" />
+  </logger>
+  <appender name="RequestResponseDetailsFileAppender" type="log4net.Appender.FileAppender">
+    <threshold value="ERROR" />
+    <file value="WebApiRequestResponseDetailsLog.log"/>
+    <appendToFile value="false"/>
+    <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5level %n ClientId: %property{ApiClientId} %n %message %n %exception" />
+    </layout>
+  </appender>
 </log4net>


### PR DESCRIPTION
In order to enable this functionality, both logger RequestResponseDetailsLogger and appender RequestResponseDetailsFileAppender must be configured, if one or both are missing, request-response details will not be logged.

request-response details log example:
`2022-12-19 19:07:26,445 [.NET ThreadPool Worker] ERROR 
 ClientId: 2 
 { RequestURL = http://localhost:54746/data/v3/ed-fi/assessments, RequestMethod = Post, ResponseCode = 400, ResponseMessage = Unable to resolve value 'uri://ed-fi.org/AssessmentCategoryDescriptor#Benchmark test2' to an existing 'AssessmentCategoryDescriptor' resource. } 
 EdFi.Ods.Common.Exceptions.BadRequestException: Unable to resolve value 'uri://ed-fi.org/AssessmentCategoryDescriptor#Benchmark test2' to an existing 'AssessmentCategoryDescriptor' resource.
   at EdFi.Ods.Api.Caching.DescriptorsCache.GetId(String descriptorName, String descriptorValue) in C:\EdFi\Ed-Fi-ODS\Application\EdFi.Ods.Api\Caching\DescriptorsCache.cs:line 131
   at EdFi.Ods.Entities.NHibernate.AssessmentAggregate.EdFi.Assessment.get_AssessmentCategoryDescriptorId() in C:\EdFi\Ed-Fi-ODS\Application\EdFi.Ods.Standard\Models\Entities\Entities.generated.cs:line 3531
   at (Object , GetterCallback )
   at NHibernate.Event.Default.DefaultFlushEntityEventListener.GetValuesAsync(Object entity, EntityEntry entry, Boolean mightBeDirty, ISessionImplementor session, CancellationToken cancellationToken)
   at NHibernate.Event.Default.DefaultFlushEntityEventListener.OnFlushEntityAsync(FlushEntityEvent event, CancellationToken cancellationToken)
   at NHibernate.Event.Default.AbstractFlushingEventListener.FlushEntitiesAsync(FlushEvent event, CancellationToken cancellationToken)
   at NHibernate.Event.Default.AbstractFlushingEventListener.FlushEverythingToExecutionsAsync(FlushEvent event, CancellationToken cancellationToken)
   at NHibernate.Event.Default.DefaultFlushEventListener.OnFlushAsync(FlushEvent event, CancellationToken cancellationToken)
   at NHibernate.Impl.SessionImpl.FlushAsync(CancellationToken cancellationToken)
   at NHibernate.Impl.SessionImpl.BeforeTransactionCompletionAsync(ITransaction tx, CancellationToken cancellationToken)
   at NHibernate.Transaction.AdoTransaction.CommitAsync(CancellationToken cancellationToken)
   at EdFi.Ods.Common.Infrastructure.Repositories.UpdateEntity`1.UpdateAsync(TEntity persistentEntity, CancellationToken cancellationToken) in C:\EdFi\Ed-Fi-ODS\Application\EdFi.Ods.Common\Infrastructure\Repositories\UpdateEntity.cs:line 43
   at EdFi.Ods.Api.Security.Authorization.Repositories.UpdateEntityAuthorizationDecorator`1.UpdateAsync(T persistentEntity, CancellationToken cancellationToken) in C:\EdFi\Ed-Fi-ODS\Application\EdFi.Ods.Api\Security\Authorization\Repositories\UpdateEntityAuthorizationDecorator.cs:line 92
   at EdFi.Ods.Common.Infrastructure.Repositories.UpsertEntity`1.UpsertAsync(TEntity entity, Boolean enforceOptimisticLock, CancellationToken cancellationToken) in C:\EdFi\Ed-Fi-ODS\Application\EdFi.Ods.Common\Infrastructure\Repositories\UpsertEntity.cs:line 97
   at EdFi.Ods.Api.Security.Authorization.Repositories.UpsertEntityAuthorizationDecorator`1.UpsertAsync(T entity, Boolean enforceOptimisticLock, CancellationToken cancellationToken) in C:\EdFi\Ed-Fi-ODS\Application\EdFi.Ods.Api\Security\Authorization\Repositories\UpsertEntityAuthorizationDecorator.cs:line 41
   at EdFi.Ods.Api.Infrastructure.Pipelines.Steps.PersistEntityModel`4.ExecuteAsync(TContext context, TResult result, CancellationToken cancellationToken) in C:\EdFi\Ed-Fi-ODS\Application\EdFi.Ods.Api\Infrastructure\Pipelines\Steps\PersistEntityModel.cs:line 36`
   
To test this functionality, do a POST of the following assessment
`{
    "contentStandard": {
      "title": "State Essential Knowledge and Skills",
      "authors": []
    },
    "assessmentIdentifier": "01774fa3-06f1-47fe-8801-c8b1e65057f2",
    "namespace": "uri://ed-fi.org/Assessment/Assessment.xml",
    "assessmentCategoryDescriptor": "uri://ed-fi.org/AssessmentCategoryDescriptor#Benchmark test2",
    "assessmentTitle": "3rd Grade Reading 1st Six Weeks 2021-2022",
    "assessmentVersion": 2021,
    "maxRawScore": 10,
    "revisionDate": "2021-09-19",
    "academicSubjects": [
      {
        "academicSubjectDescriptor": "uri://ed-fi.org/AcademicSubjectDescriptor#English Language Arts"
      }
    ],
    "assessedGradeLevels": [
      {
        "gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Third grade"
      }
    ],
    "identificationCodes": [
      {
        "assessmentIdentificationSystemDescriptor": "uri://ed-fi.org/AssessmentIdentificationSystemDescriptor#Test Contractor",
        "identificationCode": "01774fa3-06f1-47fe-8801-c8b1e65057f2"
      }
    ],
    "languages": [
      {
        "languageDescriptor": "uri://ed-fi.org/LanguageDescriptor#eng"
      }
    ],
    "performanceLevels": [],
    "periods": [],
    "platformTypes": [],
    "programs": [],
    "scores": [
      {
        "assessmentReportingMethodDescriptor": "uri://ed-fi.org/AssessmentReportingMethodDescriptor#Raw score",
        "maximumScore": "10",
        "minimumScore": "0",
        "resultDatatypeTypeDescriptor": "uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer"
      }
    ],
    "sections": []
}`

