### PR TITLE
[ODS-5660] Remove dependency on WebAdministration module in IIS installers

### DIFF
--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -427,9 +427,15 @@ function Invoke-TransformWebConfigAppSettings {
             }
             # Add a Log4net property override to specify the log's destination
             $splitPackageVersion = $Config.PackageVersion.Split(".")
+            # If $splitPackageVersion has no value, fetch the latest package version from the PackageDirectory path
+            if(-not $splitPackageVersion) {
+                $packageName = $Config.PackageName
+                $packageDirectory = $Config.PackageDirectory.Path.Split("\") | Select-Object -Last 1
+                $splitPackageVersion = $packageDirectory.Split('.') | Select-Object -Last 3
+            }
             # We only care about Major/Minor for determining the log file name
-            if ($splitPackageVersion.Count -lt 2) {
-                throw "Invalid PackageVersion provided $($Config.PackageVersion). PackageVersion must include major and minor."
+            if ($splitPackageVersion.Count -lt 3) {
+                throw "Invalid PackageVersion provided $($Config.PackageVersion). PackageVersion must include major,minor and patch."
             }
             $logDestination = $Config.LogDestinationPath.replace("{version}", -join($splitPackageVersion[0], ".", $splitPackageVersion[1]))
             if($Null -eq $settings.Log4NetCore) { 

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -152,7 +152,7 @@
     },
     "AppCommon": {
       "PackageName": "EdFi.Installer.AppCommon",
-      "PackageVersion": "3.0.0",
+      "PackageVersion": "3.1.0-pre0018",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Ods.Common": {


### PR DESCRIPTION
Tested on Powershell 5.1.19041.2364 and 7.2.8 following instructions on https://techdocs.ed-fi.org/display/ODSAPIS3V53/Getting+Started+-+Binary+Installation 
