### PR TITLE
ODS-5667 Glendale and Northridge PG 6.1 Migration

### DIFF
--- a/DatabaseTemplate/Scripts/GlendalePostgreSql.ps1
+++ b/DatabaseTemplate/Scripts/GlendalePostgreSql.ps1
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+$params = @{
+    sourceUrl = "https://odsassets.blob.core.windows.net/public/Glendale/EdFi_Ods_Glendale_v61_20230111_PG13.7z"
+    fileName  = "EdFi_Ods_Glendale_v61_20230111_PG13.7z"
+}
+
+return (& "$PSScriptRoot/../Modules/get-template-from-web.ps1" @params)

--- a/DatabaseTemplate/Scripts/NorthridgePostgreSql.ps1
+++ b/DatabaseTemplate/Scripts/NorthridgePostgreSql.ps1
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+$params = @{
+    sourceUrl = "https://odsassets.blob.core.windows.net/public/Northridge/EdFi_Ods_Northridge_v61_20230111_PG13.7z"
+    fileName  = "EdFi_Ods_Northridge_v61_20230111_PG13.7z"
+}
+
+return (& "$PSScriptRoot/../Modules/get-template-from-web.ps1" @params)


### PR DESCRIPTION
Test this code change in 6.1 Tag


From the 6.1 tag branch 


Manually update this function in this file https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/blob/main/DatabaseTemplate/Modules/database-template-source.psm1

function Get-TemplateBackupPath {
    [CmdletBinding()] param(
        [parameter(ValueFromPipeline)]
        [string]$backupFolder = $databaseTemplateDatabaseFolder,
        [parameter(ValueFromPipeline)]
        [string]$engine
    )
    if (-not (Test-Path $backupFolder)) { return }

    if($engine -eq "PostgreSQL"){
        return (Get-ChildItem $backupFolder -File -Filter "*.sql" | Select-Object -First 1 -Expand FullName)
    } else {
        return (Get-ChildItem $backupFolder -File -Filter "*.bak" | Select-Object -First 1 -Expand FullName)
    }
}

Add PR 2 files in 6.1 tag branch 

Refer https://techdocs.ed-fi.org/display/ODSAPIS3V61/How+To%3A+Use+the+Glendale+Populated+Template

update PopulatedTemplateScript to "GlendalePostgreSql"
https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/blob/main/logistics/scripts/modules/settings/settings-management.psm1#L237

dotnet user-secrets set "ApiSettings:PopulatedTemplateScript" "GlendalePostgreSql"

Run InitDev PostgreSql 

Check  PopulatedTemplate db in PGAdmin
select * from edfi.Student;
select * from edfi.EducationOrganization;

Same step for Northridge also