### PR TITLE
[ODS-4956] Sandbox 5.2 latest is encrypting the Secret after first use

### DIFF
--- a/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
+++ b/Scripts/NuGet/EdFi.Installer.WebApi/Install-EdFiOdsWebApi.psm1
@@ -453,6 +453,12 @@ function Invoke-TransformWebConfigAppSettings {
                     }
                 }
             }
+            if($Config.InstallType -eq "Sandbox") {
+                $settings.ApiSettings.PlainTextSecrets = $Config.WebApiFeatures.PlainTextSecrets
+                if($Config.WebApiFeatures.PlainTextSecrets -eq $Null) {
+                    $settings.ApiSettings.PlainTextSecrets = $true
+                }
+            }
            $settings.BearerTokenTimeoutMinutes=$Config.WebApiFeatures.BearerTokenTimeoutMinutes
            $settings.ApiSettings.ExcludedExtensions=$Config.WebApiFeatures.ExcludedExtensions
            New-JsonFile $settingsFile $settings -Overwrite


### PR DESCRIPTION
When install type is Sandbox, 

- By default, ApiSettings.PlainTextSecrets is set to true.
- If WebApiFeatures includes parameter PlainTextSecrets, will take that value, ex.
```
$parameters = @{
    PackageVersion = "6.1.901"
    DbConnectionInfo = @{
       Engine="SqlServer"
       Server="localhost"
       UseIntegratedSecurity=$true
    }
    WebApiFeatures = @{
       PlainTextSecrets=$false
    }
    InstallType = "Sandbox"
}
```

Use package EdFi.Suite3.Installer.WebApi 7.0.4 to test