### PR TITLE
[ODS-5708] Northridge as Populated Template is not always taking valid backup path for Reset-PopulatedTemplate

### DIFF
--- a/DatabaseTemplate/Modules/database-template-source.psm1
+++ b/DatabaseTemplate/Modules/database-template-source.psm1
@@ -130,10 +130,13 @@ function Initialize-TemplateSourceFromScriptName {
     $scriptPath = Get-TemplateScriptPath $scriptName
     $returnedPath = Invoke-TemplateScript $scriptPath
 
-    $returnedValidPath = ((-not [string]::IsNullOrWhiteSpace($returnedPath)) -and (Test-Path $returnedPath))
-    if ($returnedValidPath) { return $returnedPath }
-
-    return Get-TemplateBackupPath $databaseTemplateDatabaseFolder $engine
+    # $returnedPath can be a valid backup file or a folder with a valid backup inside
+    if ((Get-Item $returnedPath) -is  [System.IO.DirectoryInfo]) {
+        return Get-TemplateBackupPath $returnedPath $engine
+    }
+    else {
+        return $returnedPath
+    }
 }
 
 function Get-MinimalTemplateBackupPathFromSettings {

--- a/DatabaseTemplate/Modules/get-template-from-web.ps1
+++ b/DatabaseTemplate/Modules/get-template-from-web.ps1
@@ -42,7 +42,9 @@ Write-Host "Downloading file from $sourceUrl..."
 $webClient = New-Object System.Net.WebClient
 
 if ($isArchiveFile) {
+    if (-not (Test-Path $archiveBackupFilePath)) {
     $webClient.DownloadFile($sourceUrl, $archiveBackupFilePath)
+    }
 
     if (-not (Test-Path $archiveBackupFilePath)) {
         Write-Error "Template source file '$archiveBackupFilePath' not found."


### PR DESCRIPTION
- Will not download previously downloaded archived files
- Fixed issue where "7Zip4Powershell" was not being installed correctly
- Downloaded archive files are unpacked to a folder, not directly to Databases folder

Note: Use branch https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/tree/ODS-5708_6.1test to test