### PR TITLE
[ODS-5612] Add support for reading API Profile definitions from the EdFi_Admin database

### DIFF
--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.5.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="7.0.41" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="7.0.54" />
     <PackageReference Include="EdFi.Suite3.Security.DataAccess" Version="7.0.32" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />

--- a/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
+++ b/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.2" />
     <PackageReference Include="Autofac" Version="6.5.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="7.0.41" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="7.0.54" />
     <PackageReference Include="EdFi.Suite3.Common" Version="7.0.25" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EntityFramework6.Npgsql" Version="6.4.3" />

--- a/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
+++ b/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="7.0.41" />
+    <PackageReference Include="EdFi.Suite3.Admin.DataAccess" Version="7.0.54" />
     <PackageReference Include="FluentValidation" Version="11.4.0" />
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />

--- a/Application/EdFi.Ods.WebApi/appsettings.json
+++ b/Application/EdFi.Ods.WebApi/appsettings.json
@@ -28,7 +28,6 @@
         "OdsTokens": "",
         "OdsDatabaseTemplateName": "minimal",
         "PopulatedTemplateDBTimeOutInSeconds": "600",
-        "LoadProfilesFromDatabase": true,
         "Features": [
             {
                 "Name": "OpenApiMetadata",

--- a/Application/EdFi.Ods.WebApi/appsettings.json
+++ b/Application/EdFi.Ods.WebApi/appsettings.json
@@ -82,39 +82,39 @@
             }
         ],
         "ExcludedExtensions": [],
-      "Caching": {
-        "ExternalCacheProvider": "",
-        "Redis": {
-          "Configuration": "",
-          "Password": ""
-        },
-        "SQLServer": {
-          "ConnectionString": "",
-          "SchemaName": "",
-          "TableName": ""
-        },
-        "Descriptors": {
-          "UseExternalCache": false,
-          "AbsoluteExpirationSeconds": 1800
-        },
-        "Profiles": {
-          "AbsoluteExpirationSeconds": 1800
-        },
-        "PersonUniqueIdToUsi": {
-          "UseExternalCache": false,
-          "AbsoluteExpirationSeconds": 0,
-          "SlidingExpirationSeconds": 14400,
-          "SuppressStudentCache": false,
-          "SuppressStaffCache": false,
-          "SuppressParentCache": false
-        },
-        "ApiClientDetails": {
-          "UseExternalCache": false
-        },
-        "Security": {
-          "AbsoluteExpirationMinutes": 10
+        "Caching": {
+            "ExternalCacheProvider": "",
+            "Redis": {
+                "Configuration": "",
+                "Password": ""
+            },
+            "SQLServer": {
+                "ConnectionString": "",
+                "SchemaName": "",
+                "TableName": ""
+            },
+            "Descriptors": {
+                "UseExternalCache": false,
+                "AbsoluteExpirationSeconds": 1800
+            },
+            "PersonUniqueIdToUsi": {
+                "UseExternalCache": false,
+                "AbsoluteExpirationSeconds": 0,
+                "SlidingExpirationSeconds": 14400,
+                "SuppressStudentCache": false,
+                "SuppressStaffCache": false,
+                "SuppressParentCache": false
+            },
+            "ApiClientDetails": {
+                "UseExternalCache": false
+            },
+            "Security": {
+                "AbsoluteExpirationMinutes": 10
+            },
+            "Profiles": {
+                "AbsoluteExpirationSeconds": 1800
+            }
         }
-      }
     },
     "Plugin": {
         "Folder": "./Plugin",

--- a/Application/EdFi.Ods.WebApi/appsettings.json
+++ b/Application/EdFi.Ods.WebApi/appsettings.json
@@ -28,6 +28,7 @@
         "OdsTokens": "",
         "OdsDatabaseTemplateName": "minimal",
         "PopulatedTemplateDBTimeOutInSeconds": "600",
+        "LoadProfilesFromDatabase": true,
         "Features": [
             {
                 "Name": "OpenApiMetadata",
@@ -82,36 +83,39 @@
             }
         ],
         "ExcludedExtensions": [],
-        "Caching": {
-            "ExternalCacheProvider": "",
-            "Redis": {
-                "Configuration": "",
-                "Password": ""
-            },
-            "SQLServer": {
-                "ConnectionString": "",
-                "SchemaName": "",
-                "TableName": ""
-            },
-            "Descriptors": {
-                "UseExternalCache": false,
-                "AbsoluteExpirationSeconds": 1800
-            },
-            "PersonUniqueIdToUsi": {
-                "UseExternalCache": false,
-                "AbsoluteExpirationSeconds": 0,
-                "SlidingExpirationSeconds": 14400,
-                "SuppressStudentCache": false,
-                "SuppressStaffCache": false,
-                "SuppressParentCache": false
-            },
-            "ApiClientDetails": {
-                "UseExternalCache": false
-            },
-            "Security": {
-                "AbsoluteExpirationMinutes": 10
-            }
+      "Caching": {
+        "ExternalCacheProvider": "",
+        "Redis": {
+          "Configuration": "",
+          "Password": ""
+        },
+        "SQLServer": {
+          "ConnectionString": "",
+          "SchemaName": "",
+          "TableName": ""
+        },
+        "Descriptors": {
+          "UseExternalCache": false,
+          "AbsoluteExpirationSeconds": 1800
+        },
+        "Profiles": {
+          "AbsoluteExpirationSeconds": 1800
+        },
+        "PersonUniqueIdToUsi": {
+          "UseExternalCache": false,
+          "AbsoluteExpirationSeconds": 0,
+          "SlidingExpirationSeconds": 14400,
+          "SuppressStudentCache": false,
+          "SuppressStaffCache": false,
+          "SuppressParentCache": false
+        },
+        "ApiClientDetails": {
+          "UseExternalCache": false
+        },
+        "Security": {
+          "AbsoluteExpirationMinutes": 10
         }
+      }
     },
     "Plugin": {
         "Folder": "./Plugin",


### PR DESCRIPTION
To test, run the following script against EdFi_Admin db
```
-- For MSSQL
INSERT INTO dbo.Profiles 
  SELECT 'Sample-Profile-DB-Resource-ExcludeOnly',
  '<Profile name="Sample-Profile-DB-Resource-ExcludeOnly">
    <Resource name="School">
      <ReadContentType memberSelection="ExcludeOnly">
        <!-- Inherited property -->
        <Property name="NameOfInstitution" />
        <!-- Inherited Descriptor property -->
        <Property name="OperationalStatusDescriptor" />
        <!-- Property -->
        <Property name="CharterApprovalSchoolYearTypeReference" />
        <!-- Descriptor property -->
        <Property name="SchoolTypeDescriptor" />
        <!-- Descriptor property -->
        <Property name="AdministrativeFundingControlDescriptor" />
        <!-- Inherited Collection -->
        <Collection name="EducationOrganizationAddresses" memberSelection="IncludeAll" />
        <!-- Collection -->
        <Collection name="SchoolCategories" memberSelection="IncludeAll" />
      </ReadContentType>
      <WriteContentType memberSelection="ExcludeOnly">
        <!-- Inherited property -->
        <Property name="ShortNameOfInstitution" />
        <!-- Inherited Descriptor property -->
        <Property name="OperationalStatusDescriptor" />
        <!-- Property -->
        <Property name="WebSite" />
        <!-- Descriptor property -->
        <Property name="CharterStatusDescriptor" />
        <!-- Descriptor property -->
        <Property name="AdministrativeFundingControlDescriptor" />
        <!-- Inherited Collection -->
        <Collection name="EducationOrganizationInternationalAddresses" memberSelection="IncludeAll" />
        <!-- Collection -->
        <Collection name="SchoolGradeLevels" memberSelection="IncludeAll" />
      </WriteContentType>
    </Resource>
   </Profile>'

-- For PostgreSQL
INSERT INTO dbo.profiles(
	profilename, profiledefinition)
	VALUES ('Sample-Profile-DB-Resource-ExcludeOnly',
  '<Profile name="Sample-Profile-DB-Resource-ExcludeOnly">
    <Resource name="School">
      <ReadContentType memberSelection="ExcludeOnly">
        <!-- Inherited property -->
        <Property name="NameOfInstitution" />
        <!-- Inherited Descriptor property -->
        <Property name="OperationalStatusDescriptor" />
        <!-- Property -->
        <Property name="CharterApprovalSchoolYearTypeReference" />
        <!-- Descriptor property -->
        <Property name="SchoolTypeDescriptor" />
        <!-- Descriptor property -->
        <Property name="AdministrativeFundingControlDescriptor" />
        <!-- Inherited Collection -->
        <Collection name="EducationOrganizationAddresses" memberSelection="IncludeAll" />
        <!-- Collection -->
        <Collection name="SchoolCategories" memberSelection="IncludeAll" />
      </ReadContentType>
      <WriteContentType memberSelection="ExcludeOnly">
        <!-- Inherited property -->
        <Property name="ShortNameOfInstitution" />
        <!-- Inherited Descriptor property -->
        <Property name="OperationalStatusDescriptor" />
        <!-- Property -->
        <Property name="WebSite" />
        <!-- Descriptor property -->
        <Property name="CharterStatusDescriptor" />
        <!-- Descriptor property -->
        <Property name="AdministrativeFundingControlDescriptor" />
        <!-- Inherited Collection -->
        <Collection name="EducationOrganizationInternationalAddresses" memberSelection="IncludeAll" />
        <!-- Collection -->
        <Collection name="SchoolGradeLevels" memberSelection="IncludeAll" />
      </WriteContentType>
    </Resource>
   </Profile>');
```