### PR TITLE
[ODS-5742] Nuget package caching enabled in Github Actions builds of Ed-Fi-ODS-Implementation repo

### DIFF
--- a/.github/workflows/Cleanup Caches by a branch.yml
+++ b/.github/workflows/Cleanup Caches by a branch.yml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: Cleanup Caches by a branch
+on:
+  pull_request:
+    branches: [main, 'ODS-*']
+    types: [ closed ]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3.0.2
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          PULLREQUESTBRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $PULLREQUESTBRANCH | cut -f 1 )          
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches for  PULLREQUESTBRANCH $PULLREQUESTBRANCH..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $PULLREQUESTBRANCH --confirm
+          done
+
+          WORKINGBRANCH=${{ GITHUB.HEAD_REF }}         
+          echo "HEAD_REF: " ${{ GITHUB.HEAD_REF }}
+          echo "REF_NAME: " ${{ GITHUB.REF_NAME }}
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $WORKINGBRANCH | cut -f 1 )
+          set +e
+          echo "Deleting caches for WORKINGBRANCH $WORKINGBRANCH..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $WORKINGBRANCH --confirm
+          done          
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}

--- a/.github/workflows/CodeQL Security Scan.yml
+++ b/.github/workflows/CodeQL Security Scan.yml
@@ -64,6 +64,18 @@ jobs:
             $PSVersionTable
             . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1
             Invoke-CodeGen -Engine PostgreSQL -RepositoryRoot $env:GITHUB_WORKSPACE
+      - name: Cache Nuget packages   
+        uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+      - name: Restore NuGet packages
+        working-directory: ./Ed-Fi-ODS-Implementation/
+        run: |
+          .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+        shell: pwsh
       - name: build
         shell: pwsh
         working-directory: ./Ed-Fi-ODS-Implementation/

--- a/.github/workflows/CodeQL Security Scan.yml
+++ b/.github/workflows/CodeQL Security Scan.yml
@@ -71,6 +71,9 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
+            ${{ runner.os }}-
+            nuget-
+          enableCrossOsArchive: true
       - name: Restore NuGet packages
         working-directory: ./Ed-Fi-ODS-Implementation/
         run: |

--- a/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -78,6 +78,9 @@ jobs:
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
+          ${{ runner.os }}-
+          nuget-
+        enableCrossOsArchive: true  
     - name: Restore NuGet packages
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |

--- a/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -82,7 +82,6 @@ jobs:
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
         .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/SdkGen/EdFi.SdkGen.sln"
-        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln"
         .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
       shell: pwsh                  
     - name: ODS/API InitDev and SdkGen
@@ -106,6 +105,8 @@ jobs:
     - name: Run Unit Tests for EdFi.LoadTools 
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
+        .\build.githubactions.ps1 Restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln"
+        .\build.githubactions.ps1 Build -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln"        
         .\build.githubactions.ps1 Test -Configuration ${{ env.CONFIGURATION }} -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
       shell: pwsh
     - name: ODS/API Smoke Test Sandbox

--- a/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Restore NuGet packages
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-        .\build.githubactions.ps1 restore -Solution "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln"
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/SdkGen/EdFi.SdkGen.sln"
         .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln"
         .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
       shell: pwsh                  

--- a/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Run Unit Tests for EdFi.LoadTools 
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-           .\build.githubactions.ps1 test -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
+        .\build.githubactions.ps1 Test -Configuration ${{ env.CONFIGURATION }} -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
       shell: pwsh
     - name: ODS/API Smoke Test Sandbox
       working-directory: ./Ed-Fi-ODS-Implementation/

--- a/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev (Postgres), Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -70,7 +70,21 @@ jobs:
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-           .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"       
+           .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
+    - name: Cache Nuget packages   
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln"
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln"
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+      shell: pwsh                  
     - name: ODS/API InitDev and SdkGen
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
@@ -79,7 +93,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateTestSdkPackage -NoPackaging
+        .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateTestSdkPackage -NoPackaging  -NoRestore
       shell: pwsh
     - name: Upload initdev logs
       if: success() || failure()
@@ -92,7 +106,7 @@ jobs:
     - name: Run Unit Tests for EdFi.LoadTools 
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-           dotnet test "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln" --filter TestCategory!~'RunManually'
+           .\build.githubactions.ps1 test -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
       shell: pwsh
     - name: ODS/API Smoke Test Sandbox
       working-directory: ./Ed-Fi-ODS-Implementation/

--- a/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
+++ b/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Restore NuGet packages
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-        .\build.githubactions.ps1 restore -Solution "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln"
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/SdkGen/EdFi.SdkGen.sln"
         .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
       shell: pwsh              
     - name: ODS/API InitDev, SdkGen,Run Integration Tests, Run Unit Tests

--- a/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
+++ b/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
@@ -69,6 +69,19 @@ jobs:
       shell: pwsh
       run: |
            .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
+    - name: Cache Nuget packages   
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln"
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+      shell: pwsh              
     - name: ODS/API InitDev, SdkGen,Run Integration Tests, Run Unit Tests
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
@@ -77,7 +90,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -NoPackaging
+        .\build.github.ps1 -Engine PostgreSQL -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -NoPackaging  -NoRestore
       shell: pwsh
     - name: Upload Unit And Integration Test Reports
       if: success() || failure()

--- a/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
+++ b/.github/workflows/InitDev (Postgres),Unit tests,Integration tests.yml
@@ -76,6 +76,9 @@ jobs:
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
+          ${{ runner.os }}-
+          nuget-
+        enableCrossOsArchive: true
     - name: Restore NuGet packages
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -58,6 +58,18 @@ jobs:
       shell: pwsh
       run: |
            .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
+    - name: Cache Nuget packages   
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+      shell: pwsh
     - name: Install sql-server-2019 & sqlpackage
       shell: powershell
       run: |
@@ -81,7 +93,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -PackageOutput "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/NugetPackages"
+        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateApiSdkPackage -GenerateTestSdkPackage -RunPostman -RunPester -RunDotnetTest -PackageOutput "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/NugetPackages"  -NoRestore
       shell: pwsh
     - name: Upload Unit And Integration Test Reports
       if: success() || failure()

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -65,6 +65,9 @@ jobs:
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
+          ${{ runner.os }}-
+          nuget-
+        enableCrossOsArchive: true
     - name: Restore NuGet packages
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Package.yml
@@ -68,6 +68,7 @@ jobs:
     - name: Restore NuGet packages
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/SdkGen/EdFi.SdkGen.sln"      
         .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
       shell: pwsh
     - name: Install sql-server-2019 & sqlpackage

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -58,6 +58,20 @@ jobs:
       shell: pwsh
       run: |
            .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
+    - name: Cache Nuget packages   
+      uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 #v3.2.3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Restore NuGet packages
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      run: |
+        .\build.githubactions.ps1 restore -Solution "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln"      
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln"
+      shell: pwsh
     - name: Install sql-server-2019 & sqlpackage
       shell: powershell
       run: |
@@ -71,7 +85,7 @@ jobs:
         [int]$BuildIncrementer = "${{ env.BUILD_INCREMENTER }}"
         [int]$newRevision =  $BuildCounter + $BuildIncrementer
         [string]$version = "${{ env.VERSION_MAJOR}}"+ "." +"${{ env.VERSION_MINOR}}" + "." + $newRevision.ToString()
-        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateTestSdkPackage -NoPackaging
+        .\build.github.ps1 -PackageVersion $version -RepositoryRoot $env:GITHUB_WORKSPACE -UsePlugins -RunSdkGen -GenerateTestSdkPackage -NoPackaging -NoRestore
       shell: pwsh
     - name: Upload initdev logs
       if: success() || failure()
@@ -84,7 +98,7 @@ jobs:
     - name: Run Unit tests for EdFi.LoadTools 
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-           dotnet test "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln" --filter TestCategory!~'RunManually'
+           .\build.githubactions.ps1 test -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
       shell: pwsh
     - name: ODS/API Smoke Test Sandbox
       working-directory: ./Ed-Fi-ODS-Implementation/

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -65,6 +65,9 @@ jobs:
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj*', '**/configuration.packages.json') }}
         restore-keys: |
           ${{ runner.os }}-nuget-
+          ${{ runner.os }}-
+          nuget-
+        enableCrossOsArchive: true
     - name: Restore NuGet packages
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Restore NuGet packages
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-        .\build.githubactions.ps1 restore -Solution "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln"      
+        .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/SdkGen/EdFi.SdkGen.sln"
         .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Application/Ed-Fi-Ods.sln"
         .\build.githubactions.ps1 restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln"
       shell: pwsh

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -98,7 +98,9 @@ jobs:
     - name: Run Unit tests for EdFi.LoadTools 
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-           .\build.githubactions.ps1 Test -Configuration ${{ env.CONFIGURATION }} -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
+        .\build.githubactions.ps1 Restore -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln"
+        .\build.githubactions.ps1 Build -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln"        
+        .\build.githubactions.ps1 Test -Configuration ${{ env.CONFIGURATION }} -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
       shell: pwsh
     - name: ODS/API Smoke Test Sandbox
       working-directory: ./Ed-Fi-ODS-Implementation/

--- a/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
+++ b/.github/workflows/InitDev,Unit tests,Integration tests,Smoke Tests using Sandbox, Year-Specific and Shared Instance.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Run Unit tests for EdFi.LoadTools 
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-           .\build.githubactions.ps1 test -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
+           .\build.githubactions.ps1 Test -Configuration ${{ env.CONFIGURATION }} -Solution "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Utilities/DataLoading/LoadTools.sln" -TestFilter "RunManually"
       shell: pwsh
     - name: ODS/API Smoke Test Sandbox
       working-directory: ./Ed-Fi-ODS-Implementation/

--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -471,7 +471,7 @@ function Invoke-SdkGen {
         [string] $PackageVersion,
         [switch] $NoRestore = $false
     )
-    
+    Write-Host -ForegroundColor Magenta "Invoke-SdkGen -NoRestore is " $NoRestore
     Invoke-Task -name $MyInvocation.MyCommand.Name -task {
         & $(Get-RepositoryResolvedPath "logistics/scripts/Invoke-SdkGen.ps1") -generateApiSdkPackage $GenerateApiSdkPackage -generateTestSdkPackage $GenerateTestSdkPackage -packageVersion $PackageVersion  -noRestore $NoRestore 
     }

--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -278,7 +278,6 @@ Function Invoke-RebuildSolution {
         $solutionFileName = (Get-ItemProperty -LiteralPath $solutionPath).Name
         $buildLogFilePath = (Join-Path -Path $BuildLogDirectoryPath -ChildPath $solutionFileName) + ".msbuild.log"
 
-        Write-Host -ForegroundColor Magenta "NoRestore is " $noRestore
         Write-Host -ForegroundColor Magenta "& dotnet build $solutionPath -c $buildConfiguration -v $verbosity /flp:v=$verbosity /flp:logfile=$buildLogFilePath"
         if ($noRestore) {
             & dotnet build $solutionPath -c $buildConfiguration -v $verbosity /flp:v=$verbosity /flp:logfile=$buildLogFilePath --no-restore | Out-Host
@@ -472,7 +471,6 @@ function Invoke-SdkGen {
         [string] $PackageVersion,
         [Boolean] $NoRestore
     )
-    Write-Host -ForegroundColor Magenta "Invoke-SdkGen -NoRestore is " $NoRestore
     Invoke-Task -name $MyInvocation.MyCommand.Name -task {
         & $(Get-RepositoryResolvedPath "logistics/scripts/Invoke-SdkGen.ps1") -generateApiSdkPackage $GenerateApiSdkPackage -generateTestSdkPackage $GenerateTestSdkPackage -packageVersion $PackageVersion -noRestore $NoRestore 
     }

--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -194,7 +194,7 @@ function Initialize-DevelopmentEnvironment {
 
         if ($RunSmokeTest) { $script:result += Invoke-SmokeTests }
 
-        if ($RunSdkGen) { $script:result += Invoke-SdkGen $GenerateApiSdkPackage $GenerateTestSdkPackage $PackageVersion }
+        if ($RunSdkGen) { $script:result += Invoke-SdkGen $GenerateApiSdkPackage $GenerateTestSdkPackage $PackageVersion $NoRestore }
     }
 
     $script:result += New-TaskResult -name '-' -duration '-'
@@ -468,11 +468,12 @@ function Invoke-SdkGen {
     param(
         [Boolean] $GenerateApiSdkPackage,
         [Boolean] $GenerateTestSdkPackage,
-        [string] $PackageVersion
+        [string] $PackageVersion,
+        [switch] $NoRestore = $false
     )
     
     Invoke-Task -name $MyInvocation.MyCommand.Name -task {
-        & $(Get-RepositoryResolvedPath "logistics/scripts/Invoke-SdkGen.ps1") -generateApiSdkPackage $GenerateApiSdkPackage -generateTestSdkPackage $GenerateTestSdkPackage -packageVersion $PackageVersion
+        & $(Get-RepositoryResolvedPath "logistics/scripts/Invoke-SdkGen.ps1") -generateApiSdkPackage $GenerateApiSdkPackage -generateTestSdkPackage $GenerateTestSdkPackage -packageVersion $PackageVersion  -noRestore $NoRestore 
     }
 }
 

--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -268,6 +268,7 @@ Function Invoke-RebuildSolution {
             Path               = $solutionPath
             BuildConfiguration = $buildConfiguration
             LogVerbosityLevel  = $verbosity
+            noRestore          = $noRestore
         }
 
         ($params).GetEnumerator() | Sort-Object -Property Name | Format-Table -HideTableHeaders -AutoSize -Wrap | Out-Host

--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -258,7 +258,7 @@ Function Invoke-RebuildSolution {
         [string] $buildConfiguration = "Debug",
         [string] $verbosity = "minimal",
         [string] $solutionPath = (Get-RepositoryResolvedPath "Application/Ed-Fi-Ods.sln"),
-        [switch] $noRestore = $false
+        [Boolean] $noRestore = $false
     )
     Invoke-Task -name $MyInvocation.MyCommand.Name -task {
         if ((Get-DeploymentSettings).Engine -eq 'PostgreSQL') { $buildConfiguration = 'Npgsql' }
@@ -470,11 +470,11 @@ function Invoke-SdkGen {
         [Boolean] $GenerateApiSdkPackage,
         [Boolean] $GenerateTestSdkPackage,
         [string] $PackageVersion,
-        [switch] $NoRestore = $false
+        [Boolean] $NoRestore
     )
     Write-Host -ForegroundColor Magenta "Invoke-SdkGen -NoRestore is " $NoRestore
     Invoke-Task -name $MyInvocation.MyCommand.Name -task {
-        & $(Get-RepositoryResolvedPath "logistics/scripts/Invoke-SdkGen.ps1") -generateApiSdkPackage $GenerateApiSdkPackage -generateTestSdkPackage $GenerateTestSdkPackage -packageVersion $PackageVersion  -noRestore $NoRestore 
+        & $(Get-RepositoryResolvedPath "logistics/scripts/Invoke-SdkGen.ps1") -generateApiSdkPackage $GenerateApiSdkPackage -generateTestSdkPackage $GenerateTestSdkPackage -packageVersion $PackageVersion -noRestore $NoRestore 
     }
 }
 

--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -75,11 +75,9 @@ function Install-NpmPackages {
     $does_corresponding_package_exist = npm list -g --depth=0 |Out-String -Stream | Select-String -Pattern $package.name -SimpleMatch -Quiet
     if (!$does_corresponding_package_exist -eq $true) {
       if (Get-IsWindows) {
-        #npm install -g "$($package.name)@$($package.requiredVersion)" --verbose --cache '%AppData%\npm-cache' --prefer-offline
         npm install -g "$($package.name)@$($package.requiredVersion)" --verbose
       }
       else {
-        #sudo npm install -g "$($package.name)@$($package.requiredVersion)" --verbose --cache '~/.npm/_cacache' --prefer-offline
         sudo npm install -g "$($package.name)@$($package.requiredVersion)" --verbose  
       }
     }

--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -75,10 +75,12 @@ function Install-NpmPackages {
     $does_corresponding_package_exist = npm list -g --depth=0 |Out-String -Stream | Select-String -Pattern $package.name -SimpleMatch -Quiet
     if (!$does_corresponding_package_exist -eq $true) {
       if (Get-IsWindows) {
-        npm install -g "$($package.name)@$($package.requiredVersion)" --verbose --cache '%AppData%\npm-cache' --prefer-offline
+        #npm install -g "$($package.name)@$($package.requiredVersion)" --verbose --cache '%AppData%\npm-cache' --prefer-offline
+        npm install -g "$($package.name)@$($package.requiredVersion)" --verbose
       }
       else {
-        sudo npm install -g "$($package.name)@$($package.requiredVersion)" --verbose --cache '~/.npm/_cacache' --prefer-offline
+        #sudo npm install -g "$($package.name)@$($package.requiredVersion)" --verbose --cache '~/.npm/_cacache' --prefer-offline
+        sudo npm install -g "$($package.name)@$($package.requiredVersion)" --verbose  
       }
     }
   }

--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -78,7 +78,7 @@ function Install-NpmPackages {
         npm install -g "$($package.name)@$($package.requiredVersion)" --verbose
       }
       else {
-        sudo npm install -g "$($package.name)@$($package.requiredVersion)" --verbose  
+        sudo npm install -g "$($package.name)@$($package.requiredVersion)" --verbose
       }
     }
   }

--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -75,10 +75,10 @@ function Install-NpmPackages {
     $does_corresponding_package_exist = npm list -g --depth=0 |Out-String -Stream | Select-String -Pattern $package.name -SimpleMatch -Quiet
     if (!$does_corresponding_package_exist -eq $true) {
       if (Get-IsWindows) {
-        npm install -g "$($package.name)@$($package.requiredVersion)" --verbose
+        npm install -g "$($package.name)@$($package.requiredVersion)" --verbose --cache '%AppData%\npm-cache' --prefer-offline
       }
       else {
-        sudo npm install -g "$($package.name)@$($package.requiredVersion)" --verbose
+        sudo npm install -g "$($package.name)@$($package.requiredVersion)" --verbose --prefer-offline'~/.npm/_cacache' --prefer-offline
       }
     }
   }

--- a/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
+++ b/logistics/scripts/Invoke-PostmanIntegrationTests.ps1
@@ -78,7 +78,7 @@ function Install-NpmPackages {
         npm install -g "$($package.name)@$($package.requiredVersion)" --verbose --cache '%AppData%\npm-cache' --prefer-offline
       }
       else {
-        sudo npm install -g "$($package.name)@$($package.requiredVersion)" --verbose --prefer-offline'~/.npm/_cacache' --prefer-offline
+        sudo npm install -g "$($package.name)@$($package.requiredVersion)" --verbose --cache '~/.npm/_cacache' --prefer-offline
       }
     }
   }

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -50,7 +50,7 @@ function Invoke-SdkGen {
     $buildConfiguration = if($null -ne $envBuildConfiguration) { $envBuildConfiguration} else { Get-ValueOrDefault $teamCityParameters['msbuild.buildConfiguration'] 'Debug'}
     $version = if($packageVersion){ $packageVersion } else { (Get-ValueOrDefault $teamCityParameters['version'] '0.0.0') }
     
-    Write-Host -ForegroundColor Magenta "Inside Invoke-SdkGen -NoRestore is " $noRestore    
+    Write-Host -ForegroundColor Magenta "Invoke-SdkGen -NoRestore is " $noRestore    
     $elapsed = Use-StopWatch {
         if($generateApiSdkPackage) {
 

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -24,7 +24,8 @@ param(
     [string] $environmentFilePath = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath "modules")).Path,
     [Boolean] $generateApiSdkPackage = $false,
     [Boolean] $generateTestSdkPackage = $false,
-    [string] $packageVersion
+    [string] $packageVersion,
+    [switch] $NoRestore = $false
 )
 
 $ErrorActionPreference = 'Stop'
@@ -54,7 +55,7 @@ function Invoke-SdkGen {
 
             try {
                 $script:result += Invoke-Task "Clean-SdkGen-Console-Output" { Invoke-Clean-SdkGen-Output }
-                $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal"  $sdkGenSolution }
+                $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal"  $sdkGenSolution $NoRestore}
                 $script:result += Invoke-Task -name "Start-TestHarness" -task { Start-TestHarness $apiUrl $configurationFile $environmentFilePath $null "EdFiOdsApiSdk" }
                 $sdkCliVersion = Get-ValueOrDefault $teamCityParameters['SdkCliVersion'] '6.0.1'
                 $arguments = @("-v",$sdkCliVersion,"--core-only")
@@ -66,7 +67,7 @@ function Invoke-SdkGen {
 
             $sdkSolutionFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln")
             $script:result += Invoke-Task "Restore-ApiSdk-Packages" { Invoke-Restore-ApiSdk-Packages $sdkSolutionFile }
-            $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal" $sdkSolutionFile }
+            $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal" $sdkSolutionFile  $NoRestore }
 
             $nuspecFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.OdsApi.Sdk.nuspec")
             $suffix = Get-ValueOrDefault $teamCityParameters['odsapi.package.suffix'] ".Suite3"
@@ -81,7 +82,7 @@ function Invoke-SdkGen {
         if($generateTestSdkPackage) {
             try {
                 $script:result += Invoke-Task "Clean-SdkGen-Console-Output" { Invoke-Clean-SdkGen-Output }
-                $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal"  $sdkGenSolution }
+                $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal"  $sdkGenSolution $NoRestore}
                 $script:result += Invoke-Task -name "Start-TestHarness" -task { Start-TestHarness $apiUrl $configurationFile $environmentFilePath $null "EdFiOdsApiSdk" }
                 $sdkCliVersion = Get-ValueOrDefault $teamCityParameters['SdkCliVersion'] '6.0.1'
                 $arguments = @("-v",$sdkCliVersion,"-c","-i","-p")
@@ -93,7 +94,7 @@ function Invoke-SdkGen {
 
             $sdkSolutionFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln")
             $script:result += Invoke-Task "Restore-TestSdk-Packages" { Invoke-Restore-ApiSdk-Packages $sdkSolutionFile }
-            $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal" $sdkSolutionFile }
+            $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal" $sdkSolutionFile $NoRestore }
 
             $nuspecFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.OdsApi.Sdk.nuspec")
             $suffix = Get-ValueOrDefault $teamCityParameters['odsapi.package.suffix'] ".Suite3"

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -25,7 +25,7 @@ param(
     [Boolean] $generateApiSdkPackage = $false,
     [Boolean] $generateTestSdkPackage = $false,
     [string] $packageVersion,
-    [switch] $NoRestore = $false
+    [switch] $noRestore = $false
 )
 
 $ErrorActionPreference = 'Stop'
@@ -50,12 +50,13 @@ function Invoke-SdkGen {
     $buildConfiguration = if($null -ne $envBuildConfiguration) { $envBuildConfiguration} else { Get-ValueOrDefault $teamCityParameters['msbuild.buildConfiguration'] 'Debug'}
     $version = if($packageVersion){ $packageVersion } else { (Get-ValueOrDefault $teamCityParameters['version'] '0.0.0') }
     
+    Write-Host -ForegroundColor Magenta "Inside Invoke-SdkGen -NoRestore is " $noRestore    
     $elapsed = Use-StopWatch {
         if($generateApiSdkPackage) {
 
             try {
                 $script:result += Invoke-Task "Clean-SdkGen-Console-Output" { Invoke-Clean-SdkGen-Output }
-                $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal"  $sdkGenSolution $NoRestore}
+                $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal"  $sdkGenSolution $noRestore}
                 $script:result += Invoke-Task -name "Start-TestHarness" -task { Start-TestHarness $apiUrl $configurationFile $environmentFilePath $null "EdFiOdsApiSdk" }
                 $sdkCliVersion = Get-ValueOrDefault $teamCityParameters['SdkCliVersion'] '6.0.1'
                 $arguments = @("-v",$sdkCliVersion,"--core-only")
@@ -67,7 +68,7 @@ function Invoke-SdkGen {
 
             $sdkSolutionFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln")
             $script:result += Invoke-Task "Restore-ApiSdk-Packages" { Invoke-Restore-ApiSdk-Packages $sdkSolutionFile }
-            $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal" $sdkSolutionFile  $NoRestore }
+            $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal" $sdkSolutionFile  $noRestore }
 
             $nuspecFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.OdsApi.Sdk.nuspec")
             $suffix = Get-ValueOrDefault $teamCityParameters['odsapi.package.suffix'] ".Suite3"
@@ -82,7 +83,7 @@ function Invoke-SdkGen {
         if($generateTestSdkPackage) {
             try {
                 $script:result += Invoke-Task "Clean-SdkGen-Console-Output" { Invoke-Clean-SdkGen-Output }
-                $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal"  $sdkGenSolution $NoRestore}
+                $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal"  $sdkGenSolution $noRestore}
                 $script:result += Invoke-Task -name "Start-TestHarness" -task { Start-TestHarness $apiUrl $configurationFile $environmentFilePath $null "EdFiOdsApiSdk" }
                 $sdkCliVersion = Get-ValueOrDefault $teamCityParameters['SdkCliVersion'] '6.0.1'
                 $arguments = @("-v",$sdkCliVersion,"-c","-i","-p")
@@ -94,7 +95,7 @@ function Invoke-SdkGen {
 
             $sdkSolutionFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/csharp/EdFi.OdsApi.Sdk.sln")
             $script:result += Invoke-Task "Restore-TestSdk-Packages" { Invoke-Restore-ApiSdk-Packages $sdkSolutionFile }
-            $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal" $sdkSolutionFile $NoRestore }
+            $script:result += Invoke-Task "Invoke-RebuildSolution" { Invoke-RebuildSolution $buildConfiguration "minimal" $sdkSolutionFile $noRestore }
 
             $nuspecFile = (Get-RepositoryResolvedPath "Utilities/SdkGen/EdFi.SdkGen.Console/EdFi.OdsApi.Sdk.nuspec")
             $suffix = Get-ValueOrDefault $teamCityParameters['odsapi.package.suffix'] ".Suite3"

--- a/logistics/scripts/Invoke-SdkGen.ps1
+++ b/logistics/scripts/Invoke-SdkGen.ps1
@@ -25,7 +25,7 @@ param(
     [Boolean] $generateApiSdkPackage = $false,
     [Boolean] $generateTestSdkPackage = $false,
     [string] $packageVersion,
-    [switch] $noRestore = $false
+    [Boolean] $noRestore = $false
 )
 
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
In general, it's not recommended to share the NuGet package cache across operating systems. NuGet packages may include platform-specific binaries or dependencies, and they may not work correctly on different operating systems.

Note that if you use the same cache key for multiple operating systems, you should make sure that the NuGet packages are compatible with all operating systems. Some packages may include platform-specific binaries or dependencies, and they may not work correctly on different operating systems. In that case, you should use separate cache keys for each operating system to ensure that the packages are only used on compatible systems. That's the reason we have 2 caches in this ODS Implementation Repo