### PR TITLE
[ODS-5764] Profile usage is not enforced (v5.1)

### DIFF
--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/appsettings.json
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/appsettings.json
@@ -39,7 +39,7 @@
       },
       {
         "Name": "Profiles",
-        "IsEnabled": false
+        "IsEnabled": true
       },
       {
         "Name": "ChangeQueries",


### PR DESCRIPTION
Enabled Profiles feature on integration test harness.