### PR TITLE
[ODS-5766] Add the Standard version to the minimal and populated templates

### DIFF
--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -325,11 +325,6 @@ function Reset-EmptySandboxDatabase {
 }
 
 function Reset-TestAdminDatabase {
-    param(
-        [String] $StandardVersion,
-        [String] $ExtensionVersion
-    )
-
     Invoke-Task -name $MyInvocation.MyCommand.Name -task {
         $settings = Get-DeploymentSettings
         # turn on all available features for the test database to ensure all the schema components are available
@@ -337,7 +332,7 @@ function Reset-TestAdminDatabase {
         $settings.ApiSettings.DropDatabases = $true
         $databaseType = $settings.ApiSettings.DatabaseTypes.Admin
         $csb = Get-DbConnectionStringBuilderFromTemplate -templateCSB $settings.ApiSettings.csbs[$settings.ApiSettings.ConnectionStringKeys[$settings.ApiSettings.DatabaseTypes.Ods]] -replacementTokens 'Admin_Test'
-        Initialize-EdFiDatabase $settings $databaseType $csb -StandardVersion $StandardVersion -ExtensionVersion $ExtensionVersion
+        Initialize-EdFiDatabase $settings $databaseType $csb
     }
 }
 

--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -325,6 +325,11 @@ function Reset-EmptySandboxDatabase {
 }
 
 function Reset-TestAdminDatabase {
+    param(
+        [String] $StandardVersion,
+        [String] $ExtensionVersion
+    )
+
     Invoke-Task -name $MyInvocation.MyCommand.Name -task {
         $settings = Get-DeploymentSettings
         # turn on all available features for the test database to ensure all the schema components are available
@@ -332,7 +337,7 @@ function Reset-TestAdminDatabase {
         $settings.ApiSettings.DropDatabases = $true
         $databaseType = $settings.ApiSettings.DatabaseTypes.Admin
         $csb = Get-DbConnectionStringBuilderFromTemplate -templateCSB $settings.ApiSettings.csbs[$settings.ApiSettings.ConnectionStringKeys[$settings.ApiSettings.DatabaseTypes.Ods]] -replacementTokens 'Admin_Test'
-        Initialize-EdFiDatabase $settings $databaseType $csb
+        Initialize-EdFiDatabase $settings $databaseType $csb -StandardVersion $StandardVersion -ExtensionVersion $ExtensionVersion
     }
 }
 

--- a/DatabaseTemplate/Modules/create-database-template.psm1
+++ b/DatabaseTemplate/Modules/create-database-template.psm1
@@ -57,7 +57,7 @@ function Get-DefaultTemplateConfiguration([hashtable] $config = @{ }) {
     $bulkLoadClientExecutableFileName = "EdFi.BulkLoadClient.Console$(GetExeExtension)"
     $config.bulkLoadClientExecutable = "$(Get-RepositoryResolvedPath "Utilities/DataLoading/EdFi.BulkLoadClient.Console")/bin/**/$bulkLoadClientExecutableFileName"
     $config.bulkLoadBootstrapInterchanges = @("InterchangeDescriptors", "InterchangeStandards", "InterchangeEducationOrganization")
-    $config.bulkLoadDirectoryMetadata = (Get-RepositoryResolvedPath "Application/EdFi.Ods.Standard/Artifacts/Metadata/")
+    $config.bulkLoadDirectoryMetadata = (Get-RepositoryResolvedPath "Application/EdFi.Ods.Standard/Standard/" + $config.standardVersion + "/Artifacts/Metadata/")
     $config.bulkLoadTempDirectory = Join-Path ([IO.Path]::GetTempPath()) "CreateDatabaseTemplate"
     $config.bulkLoadTempDirectorySchema = Join-Path $config.bulkLoadTempDirectory "Schemas"
     $config.bulkLoadTempDirectoryBootstrap = Join-Path $config.bulkLoadTempDirectory "Bootstrap"
@@ -513,7 +513,15 @@ function New-DatabaseTemplateNuspec {
         $config.databaseBackupName += ".PostgreSQL"
         $config.Id += ".PostgreSQL"
         $config.Title += ".PostgreSQL"
-        $config.Description += "for PostgreSQL"
+        $config.Description += " for PostgreSQL"
+    }
+
+    if ($config.StandardVersion) {
+        $packageNuspecName += ".Standard." + $config.StandardVersion
+        $config.databaseBackupName += ".Standard." + $config.StandardVersion
+        $config.Id += ".Standard." + $config.StandardVersion
+        $config.Title += ".Standard." + $config.StandardVersion
+        $config.Description += " with StandardVersion " + $config.StandardVersion
     }
 
     if (-not $config.backupDirectory) { $populatedTemplatePath = $global:templateDatabaseFolder }

--- a/DatabaseTemplate/Modules/create-minimal-template.psm1
+++ b/DatabaseTemplate/Modules/create-minimal-template.psm1
@@ -26,7 +26,7 @@ function Get-MinimalConfiguration([hashtable] $config = @{ }) {
     $config.Description = "EdFi Ods Minimal Template Database"
     $config.Authors = "Ed-Fi Alliance"
     $config.Owners = "Ed-Fi Alliance"
-    $config.Copyright = "Copyright @ $(Get-Date -format yyyy) Ed-Fi Alliance, LLC and Contributors"
+    $config.Copyright = "Copyright @ 2021 Ed-Fi Alliance, LLC and Contributors"
     return $config
 }
 

--- a/DatabaseTemplate/Modules/create-minimal-template.psm1
+++ b/DatabaseTemplate/Modules/create-minimal-template.psm1
@@ -11,7 +11,7 @@ Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate
 
 function Get-MinimalConfiguration([hashtable] $config = @{ }) {
 
-    $config = Merge-Hashtables (Get-DefaultTemplateConfiguration), $config
+    $config = Merge-Hashtables (Get-DefaultTemplateConfiguration $config), $config
 
     $config.Remove('apiClientNameSandbox')
 
@@ -26,7 +26,7 @@ function Get-MinimalConfiguration([hashtable] $config = @{ }) {
     $config.Description = "EdFi Ods Minimal Template Database"
     $config.Authors = "Ed-Fi Alliance"
     $config.Owners = "Ed-Fi Alliance"
-    $config.Copyright = "Copyright @ 2021 Ed-Fi Alliance, LLC and Contributors"
+    $config.Copyright = "Copyright @ $(Get-Date -format yyyy) Ed-Fi Alliance, LLC and Contributors"
     return $config
 }
 
@@ -78,7 +78,8 @@ function Initialize-MinimalTemplate {
         [switch] $noExtensions,
         [switch] $noValidation,
         [ValidateSet('SQLServer', 'PostgreSQL')]
-        [String] $engine = 'SQLServer'
+        [String] $engine = 'SQLServer',
+        [String] $standardVersion = '4.0.0'
     )
 
     Clear-Error
@@ -88,6 +89,7 @@ function Initialize-MinimalTemplate {
         noExtensions = $noExtensions
         noValidation = $noValidation
         engine       = $engine
+        standardVersion = $standardVersion
     }
 
     $config = (Get-MinimalConfiguration $paramConfig)

--- a/DatabaseTemplate/Modules/create-populated-template.psm1
+++ b/DatabaseTemplate/Modules/create-populated-template.psm1
@@ -11,7 +11,7 @@ Import-Module -Force -Scope Global (Get-RepositoryResolvedPath "DatabaseTemplate
 
 function Get-PopulatedConfiguration([hashtable] $config = @{ }) {
 
-    $config = Merge-Hashtables (Get-DefaultTemplateConfiguration), $config
+    $config = Merge-Hashtables (Get-DefaultTemplateConfiguration $config), $config
 
     $config.databaseBackupName = "EdFi.Ods.Populated.Template"
     $config.packageNuspecName = "EdFi.Ods.Populated.Template"
@@ -20,7 +20,7 @@ function Get-PopulatedConfiguration([hashtable] $config = @{ }) {
     $config.Description = "EdFi Ods Populated Template Database"
     $config.Authors = "Ed-Fi Alliance"
     $config.Owners = "Ed-Fi Alliance"
-    $config.Copyright = "Copyright @ 2021 Ed-Fi Alliance, LLC and Contributors"
+    $config.Copyright = "Copyright @ $(Get-Date -format yyyy) Ed-Fi Alliance, LLC and Contributors"
     return $config
 }
 
@@ -72,7 +72,8 @@ function Initialize-PopulatedTemplate {
         [switch] $noExtensions,
         [switch] $noValidation,
         [ValidateSet('SQLServer', 'PostgreSQL')]
-        [String] $engine = 'SQLServer'
+        [String] $engine = 'SQLServer',
+        [String] $standardVersion = '4.0.0'
     )
 
     Clear-Error
@@ -82,6 +83,7 @@ function Initialize-PopulatedTemplate {
         noExtensions = $noExtensions
         noValidation = $noValidation
         engine       = $engine
+        standardVersion = $standardVersion
     }
 
     $config = (Get-PopulatedConfiguration $paramConfig)

--- a/DatabaseTemplate/Modules/create-populated-template.psm1
+++ b/DatabaseTemplate/Modules/create-populated-template.psm1
@@ -20,7 +20,7 @@ function Get-PopulatedConfiguration([hashtable] $config = @{ }) {
     $config.Description = "EdFi Ods Populated Template Database"
     $config.Authors = "Ed-Fi Alliance"
     $config.Owners = "Ed-Fi Alliance"
-    $config.Copyright = "Copyright @ $(Get-Date -format yyyy) Ed-Fi Alliance, LLC and Contributors"
+    $config.Copyright = "Copyright @ 2021 Ed-Fi Alliance, LLC and Contributors"
     return $config
 }
 

--- a/DatabaseTemplate/Modules/database-template-source.psm1
+++ b/DatabaseTemplate/Modules/database-template-source.psm1
@@ -127,8 +127,13 @@ function Initialize-TemplateSourceFromScriptName {
         [string] $engine = 'SQLServer'
     )
 
+    $filePath = "./configuration.packages.json"
     $scriptPath = Get-TemplateScriptPath $scriptName
+
+    $originalConfig = Get-Content $filePath | ConvertFrom-Json
+    Update-PackageName $scriptName  $filePath
     $returnedPath = Invoke-TemplateScript $scriptPath
+    $originalConfig | ConvertTo-Json | Format-Json | Out-File -FilePath $filePath -Encoding UTF8
 
     # $returnedPath can be a valid backup file or a folder with a valid backup inside
     if ((Get-Item $returnedPath) -is  [System.IO.DirectoryInfo]) {
@@ -137,6 +142,18 @@ function Initialize-TemplateSourceFromScriptName {
     else {
         return $returnedPath
     }
+}
+
+function Update-PackageName([string] $scriptName, [string] $filePath) {
+
+    $config = Get-Content $filePath | ConvertFrom-Json
+    $packageName = $config.packages.($scriptName).PackageName
+
+    $StandardVersion = $Settings.ApiSettings.StandardVersion
+
+    $config.packages.($scriptName).PackageName = $packageName.Replace("{StandardVersion}",$StandardVersion).Replace("{ExtensionVersion}", $Settings.ApiSettings.ExtensionVersion)
+    $config | ConvertTo-Json | Format-Json | Out-File -FilePath $filePath -Encoding UTF8
+
 }
 
 function Get-MinimalTemplateBackupPathFromSettings {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -67,7 +67,7 @@
     },
     "EdFi.Db.Deploy": {
       "PackageName": "EdFi.Suite3.Db.Deploy",
-      "PackageVersion": "3.1.24",
+      "PackageVersion": "4.0.18",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Database.Admin.PostgreSQL": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -1,23 +1,23 @@
 ﻿{
   "packages": {
     "EdFiMinimalTemplate": {
-      "PackageName": "EdFi.Suite3.Ods.Minimal.Template",
-      "PackageVersion": "7.0.725",
+      "PackageName": "EdFi.Suite3.Ods.Minimal.Template.Standard.{StandardVersion}",
+      "PackageVersion": "7.0.740",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "GrandBend": {
-      "PackageName": "EdFi.Suite3.Ods.Populated.Template",
-      "PackageVersion": "7.0.672",
+      "PackageName": "EdFi.Suite3.Ods.Populated.Template.Standard.{StandardVersion}",
+      "PackageVersion": "7.0.681",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlMinimalTemplate": {
-      "PackageName": "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL",
-      "PackageVersion": "7.0.624",
+      "PackageName": "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL.Standard.{StandardVersion}",
+      "PackageVersion": "7.0.635",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlPopulatedTemplate": {
-      "PackageName": "EdFi.Suite3.Ods.Populated.Template.PostgreSQL",
-      "PackageVersion": "7.0.593",
+      "PackageName": "EdFi.Suite3.Ods.Populated.Template.PostgreSQL.Standard.{StandardVersion}",
+      "PackageVersion": "7.0.632",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCoreMinimalTemplate": {

--- a/logistics/scripts/modules/database/database-lifecycle.psm1
+++ b/logistics/scripts/modules/database/database-lifecycle.psm1
@@ -145,13 +145,7 @@ function Get-SQLServerDatabaseScriptStrategy {
         $Database,
 
         [Parameter(Mandatory = $true)]
-        [System.Data.Common.DbConnectionStringBuilder] $csb,
-
-        [String]
-        $StandardVersion = '4.0.0',
-
-        [String]
-        $ExtensionVersion = '1.1.0'
+        [System.Data.Common.DbConnectionStringBuilder] $csb
     )
 
     Write-Host "Executing SQLServerDatabaseScriptStrategy..."
@@ -162,8 +156,8 @@ function Get-SQLServerDatabaseScriptStrategy {
         ConnectionString = $csb
         FilePaths        = $Settings.ApiSettings.FilePaths
         Features         = $Settings.ApiSettings.SubTypes
-        StandardVersion  = $StandardVersion
-        ExtensionVersion = $ExtensionVersion
+        StandardVersion  = $Settings.ApiSettings.StandardVersion
+        ExtensionVersion = $Settings.ApiSettings.ExtensionVersion
     }
     if ($Database -eq $Settings.ApiSettings.DatabaseTypes.Ods) { $params.DatabaseTimeoutInSeconds = $Settings.ApiSettings.PopulatedTemplateDBTimeOutInSeconds }
     Invoke-DbDeploy @params
@@ -324,13 +318,7 @@ function New-EdFiDatabaseLifecycle {
         $CreateStrategy,
 
         [scriptblock]
-        $ScriptStrategy,
-
-        [String]
-        $StandardVersion = '4.0.0',
-
-        [String]
-        $ExtensionVersion = '1.1.0'
+        $ScriptStrategy
     )
 
     $params = @{}
@@ -402,13 +390,7 @@ function Initialize-EdFiDatabase {
         $CreateStrategy,
 
         [scriptblock]
-        $ScriptStrategy,
-
-        [String]
-        $StandardVersion = '4.0.0',
-
-        [String]
-        $ExtensionVersion = '1.1.0'
+        $ScriptStrategy
     )
 
     Write-InvocationInfo $MyInvocation

--- a/logistics/scripts/modules/database/database-lifecycle.psm1
+++ b/logistics/scripts/modules/database/database-lifecycle.psm1
@@ -145,7 +145,13 @@ function Get-SQLServerDatabaseScriptStrategy {
         $Database,
 
         [Parameter(Mandatory = $true)]
-        [System.Data.Common.DbConnectionStringBuilder] $csb
+        [System.Data.Common.DbConnectionStringBuilder] $csb,
+
+        [String]
+        $StandardVersion = '4.0.0',
+
+        [String]
+        $ExtensionVersion = '1.1.0'
     )
 
     Write-Host "Executing SQLServerDatabaseScriptStrategy..."
@@ -156,6 +162,8 @@ function Get-SQLServerDatabaseScriptStrategy {
         ConnectionString = $csb
         FilePaths        = $Settings.ApiSettings.FilePaths
         Features         = $Settings.ApiSettings.SubTypes
+        StandardVersion  = $StandardVersion
+        ExtensionVersion = $ExtensionVersion
     }
     if ($Database -eq $Settings.ApiSettings.DatabaseTypes.Ods) { $params.DatabaseTimeoutInSeconds = $Settings.ApiSettings.PopulatedTemplateDBTimeOutInSeconds }
     Invoke-DbDeploy @params
@@ -316,7 +324,13 @@ function New-EdFiDatabaseLifecycle {
         $CreateStrategy,
 
         [scriptblock]
-        $ScriptStrategy
+        $ScriptStrategy,
+
+        [String]
+        $StandardVersion = '4.0.0',
+
+        [String]
+        $ExtensionVersion = '1.1.0'
     )
 
     $params = @{}
@@ -388,7 +402,13 @@ function Initialize-EdFiDatabase {
         $CreateStrategy,
 
         [scriptblock]
-        $ScriptStrategy
+        $ScriptStrategy,
+
+        [String]
+        $StandardVersion = '4.0.0',
+
+        [String]
+        $ExtensionVersion = '1.1.0'
     )
 
     Write-InvocationInfo $MyInvocation

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -265,7 +265,13 @@ function Invoke-DbDeploy {
 
         [string] $ToolsPath = (Get-ToolsPath),
 
-        [Int] $DatabaseTimeoutInSeconds = 600
+        [Int] $DatabaseTimeoutInSeconds = 600,
+
+        [String]
+        $StandardVersion = '4.0.0',
+
+        [String]
+        $ExtensionVersion = '1.1.0'
     )
 
     $databaseIdLookup = @{
@@ -286,7 +292,9 @@ function Invoke-DbDeploy {
         "--database", $databaseType,
         "--connectionString", $ConnectionString,
         "--timeOut", $DatabaseTimeoutInSeconds,
-        "--filePaths", ($FilePaths -join ',')
+        "--filePaths", ($FilePaths -join ','),
+        "--standardVersion", $StandardVersion,
+        "--extensionVersion", $ExtensionVersion
     )
 
     if ($Features.count -gt 0) { $params += @('--features', ($Features -join ',')) }


### PR DESCRIPTION
To test the database packages are loaded correctly, run initdev without the tpdm plugin, this should load minimal and populated templates for the specified database engine

![image](https://user-images.githubusercontent.com/43448209/229256764-3bd7b4fc-c1d7-4009-8674-c078a7ab15f1.png)
