### PR TITLE
[ODS-5794] Enhance Request-Response logging with profile header information

### DIFF
--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/log4net.config
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/log4net.config
@@ -40,7 +40,7 @@
     <maximumFileSize value="5MB" />
     <maxSizeRollBackups value="10" />
     <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level ClientId:%property{ApiClientId} RequestUrl:%property{RequestUrl} RequestMethod:%property{RequestMethod} ResponseCode:%property{ResponseCode} ResponseMessage:%message%n" />
+        <conversionPattern value="%date [%thread] %-5level ClientId:%property{ApiClientId} RequestUrl:%property{RequestUrl} RequestMethod:%property{RequestMethod} ProfilesHeader:%property{ProfilesHeader} ResponseCode:%property{ResponseCode} ResponseMessage:%message%n" />
     </layout>
   </appender>
 </log4net>

--- a/Application/EdFi.Ods.WebApi/log4net.config
+++ b/Application/EdFi.Ods.WebApi/log4net.config
@@ -48,7 +48,7 @@
     <maximumFileSize value="100KB" />
     <maxSizeRollBackups value="7" />
     <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level ClientId:%property{ApiClientId} RequestUrl:%property{RequestUrl} RequestMethod:%property{RequestMethod} ResponseCode:%property{ResponseCode} ResponseMessage:%message%n" />
+        <conversionPattern value="%date [%thread] %-5level ClientId:%property{ApiClientId} RequestUrl:%property{RequestUrl} RequestMethod:%property{RequestMethod} ProfilesHeader:%property{ProfilesHeader} ResponseCode:%property{ResponseCode} ResponseMessage:%message%n" />
     </layout>
   </appender>
 </log4net>

--- a/Application/EdFi.Ods.WebApi/log4net.development.config
+++ b/Application/EdFi.Ods.WebApi/log4net.development.config
@@ -42,7 +42,7 @@
     <file value="WebApiRequestResponseDetailsLog.log"/>
     <appendToFile value="false"/>
     <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level ClientId:%property{ApiClientId} RequestUrl:%property{RequestUrl} RequestMethod:%property{RequestMethod} ResponseCode:%property{ResponseCode} ResponseMessage:%message%n" />
+        <conversionPattern value="%date [%thread] %-5level ClientId:%property{ApiClientId} RequestUrl:%property{RequestUrl} RequestMethod:%property{RequestMethod} ProfilesHeader:%property{ProfilesHeader} ResponseCode:%property{ResponseCode} ResponseMessage:%message%n" />
     </layout>
   </appender>
 </log4net>


### PR DESCRIPTION
Include any profiles header (content-type header starting with "application/vnd.ed-fi." ) sent by an API client in the RequestResponseDetails log messages. The field is left blank in the log message if the client does not provide a profiles header in the request.
Example of log message including a profiles header:
`2023-04-19 19:19:16,898 [64] INFO  ClientId:43 RequestUrl:http://localhost:8765/data/v3/ed-fi/schools RequestMethod:POST ProfilesHeader:application/vnd.ed-fi.school.Test-Profile-Resource-WriteOnly.writable+json ResponseCode:403 ResponseMessage:Forbidden` 