### PR TITLE
[ODS-5813] Fix CodeQL builds

### DIFF
--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -390,8 +390,8 @@ function Invoke-CodeGen {
         [switch] $IncludePlugins,
         [string[]] $ExtensionPaths,
         [String] $RepositoryRoot,
-        [String] $StandardVersion,
-        [String] $ExtensionVersion
+        [String] $StandardVersion = '4.0.0',
+        [String] $ExtensionVersion = '1.1.0'
     )
 
     Install-CodeGenUtility


### PR DESCRIPTION
This change allows to run invoke-codegen without standard and extension version params, using the default values

![image](https://user-images.githubusercontent.com/43448209/233743393-f31c56b7-bad1-4db7-9c26-514a1901693a.png)

Fixes
https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/actions/runs/4760223779/jobs/8460328494
https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/runs/4760111221/jobs/8460095416
https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/runs/4760204619/jobs/8460290085 