### PR TITLE
[ODS-5913] Encrypt connection strings in Admin database

### DIFF
--- a/Application/EdFi.Ods.WebApi/appsettings.json
+++ b/Application/EdFi.Ods.WebApi/appsettings.json
@@ -23,6 +23,7 @@
         "PopulatedTemplateScript": "GrandBend",
         "OdsTokens": "",
         "OdsDatabaseTemplateName": "minimal",
+        "OdsConnectionStringEncryptionKey": "",
         "PopulatedTemplateDBTimeOutInSeconds": "600",
         "BearerTokenTimeoutMinutes": "30",
         "DefaultPageSizeLimit": 500,


### PR DESCRIPTION
This adds an empty OdsConnectionStringEncryptionKey setting to web API appsettings.json for use with automated deployment.