### PR TITLE
[ODS-5921] Postman test coverage for Contacts (after renamed from Parent in the standard)

### DIFF
--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
@@ -171,8 +171,17 @@ namespace EdFi.Ods.Api.IntegrationTestHarness
                         new ValueItem
                         {
                             Enabled = true, 
-                            Value = dataStandardHasParentEntity ? "Parent" : "Contact",
+                            Value = dataStandardHasParentEntity ? "StudentParentAssociation" : "StudentContactAssociation",
                             Key = "StudentParentOrContactAssociationName" 
+                            
+                        });
+                    
+                    postmanEnvironment.Values.Add(
+                        new ValueItem
+                        {
+                            Enabled = true, 
+                            Value = dataStandardHasParentEntity ? "StudentParentAssociations" : "StudentContactAssociations",
+                            Key = "StudentParentOrContactAssociationCollectionName" 
                             
                         });
 

--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
@@ -166,6 +166,15 @@ namespace EdFi.Ods.Api.IntegrationTestHarness
                             Key = "ParentOrContactProperName" 
                             
                         });
+                    
+                    postmanEnvironment.Values.Add(
+                        new ValueItem
+                        {
+                            Enabled = true, 
+                            Value = dataStandardHasParentEntity ? "Parent" : "Contact",
+                            Key = "StudentParentOrContactAssociationName" 
+                            
+                        });
 
                         var jsonString = JsonConvert.SerializeObject(
                         postmanEnvironment,

--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
@@ -96,12 +96,17 @@ namespace EdFi.Ods.Api.IntegrationTestHarness
 
             void CreateEnvironmentFile()
             {
-                // Check if the Ed-Fi Data Standard schema in use has a Parent entity which was replaced by Contact in a later version of the standard.
-                // If it does not, then we assume the Contact entity is the one to use.
-                // This is used to determine which identifiers to include in the Postman environment.
+                // This checks if the Ed-Fi Data Standard in use has a Parent entity,
+                // which was renamed to Contact in Data Standard version 5.0.0.
+                
+                // If there is not a Parent entity present in the data standard in use,
+                // then we assume that the data standard in use is 5.0.0 or later and therefore use Contact.
+
                 var dataStandardHasParentEntity = _domainModelProvider.GetDomainModel().Entities.Any(x =>
                     x.Schema.Equals("edfi", StringComparison.OrdinalIgnoreCase) &&
-                    (x.Name.Equals("Parent", StringComparison.OrdinalIgnoreCase)));
+                    x.Name.Equals("Parent", StringComparison.OrdinalIgnoreCase));
+                
+                var parentOrContactProperName = dataStandardHasParentEntity ? "Parent" : "Contact";
 
                 var environmentFilePath = _configuration.GetValue<string>("environmentFilePath");
 
@@ -131,58 +136,54 @@ namespace EdFi.Ods.Api.IntegrationTestHarness
                             Key = "ProfilesFeatureIsEnabled"
                         });
                     
+                    // The following variables provide the Postman collections with the correct parent/
+                    // contact related names for the Ed-Fi data standard currently in use.
                     postmanEnvironment.Values.Add(
                         new ValueItem
                         {
                             Enabled = true, 
-                            Value = dataStandardHasParentEntity ? "parentUniqueId" : "contactUniqueId",
-                            Key = "ParentOrContactUniqueIdName" 
-                            
+                            Value = $"{parentOrContactProperName.ToLower()}UniqueId",
+                            Key = "ParentOrContactUniqueIdName"
                         });
                     
                     postmanEnvironment.Values.Add(
                         new ValueItem
                         {
                             Enabled = true, 
-                            Value = dataStandardHasParentEntity ? "parent" : "contact",
-                            Key = "ParentOrContactName" 
-                            
+                            Value = parentOrContactProperName.ToLower(),
+                            Key = "ParentOrContactName"
                         });
                     
                     postmanEnvironment.Values.Add(
                         new ValueItem
                         {
                             Enabled = true, 
-                            Value = dataStandardHasParentEntity ? "parents" : "contacts",
-                            Key = "ParentOrContactCollectionName" 
-                            
+                            Value = $"{parentOrContactProperName.ToLower()}s",
+                            Key = "ParentOrContactCollectionName"
                         });
                     
                     postmanEnvironment.Values.Add(
                         new ValueItem
                         {
                             Enabled = true, 
-                            Value = dataStandardHasParentEntity ? "Parent" : "Contact",
-                            Key = "ParentOrContactProperName" 
-                            
+                            Value = parentOrContactProperName,
+                            Key = "ParentOrContactProperName"
                         });
                     
                     postmanEnvironment.Values.Add(
                         new ValueItem
                         {
                             Enabled = true, 
-                            Value = dataStandardHasParentEntity ? "StudentParentAssociation" : "StudentContactAssociation",
-                            Key = "StudentParentOrContactAssociationName" 
-                            
+                            Value = $"Student{parentOrContactProperName}Association",
+                            Key = "StudentParentOrContactAssociationName"
                         });
                     
                     postmanEnvironment.Values.Add(
                         new ValueItem
                         {
                             Enabled = true, 
-                            Value = dataStandardHasParentEntity ? "StudentParentAssociations" : "StudentContactAssociations",
-                            Key = "StudentParentOrContactAssociationCollectionName" 
-                            
+                            Value = $"Student{parentOrContactProperName}Associations",
+                            Key = "StudentParentOrContactAssociationCollectionName"
                         });
 
                         var jsonString = JsonConvert.SerializeObject(
@@ -309,7 +310,6 @@ namespace EdFi.Ods.Api.IntegrationTestHarness
                         {
                             _clientAppRepo.AddApiClientOwnershipTokens(client.ApiClientOwnershipTokens, apiClient.ApiClientId);
                         }
-
                     }
 
                     if (app.Profiles != null)

--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
@@ -136,32 +136,8 @@ namespace EdFi.Ods.Api.IntegrationTestHarness
                             Key = "ProfilesFeatureIsEnabled"
                         });
                     
-                    // The following variables provide the Postman collections with the correct parent/
-                    // contact related names for the Ed-Fi data standard currently in use.
-                    postmanEnvironment.Values.Add(
-                        new ValueItem
-                        {
-                            Enabled = true, 
-                            Value = $"{parentOrContactProperName}UniqueId",
-                            Key = "ParentOrContactUniqueIdName"
-                        });
-                    
-                    postmanEnvironment.Values.Add(
-                        new ValueItem
-                        {
-                            Enabled = true, 
-                            Value = parentOrContactProperName.ToLower(),
-                            Key = "ParentOrContactName"
-                        });
-                    
-                    postmanEnvironment.Values.Add(
-                        new ValueItem
-                        {
-                            Enabled = true, 
-                            Value = $"{parentOrContactProperName.ToLower()}s",
-                            Key = "ParentOrContactCollectionName"
-                        });
-                    
+                    // The following variable provides the Postman collections with the correct parent/
+                    // contact related entity name for the Ed-Fi data standard currently in use.
                     postmanEnvironment.Values.Add(
                         new ValueItem
                         {
@@ -169,24 +145,8 @@ namespace EdFi.Ods.Api.IntegrationTestHarness
                             Value = parentOrContactProperName,
                             Key = "ParentOrContactProperName"
                         });
-                    
-                    postmanEnvironment.Values.Add(
-                        new ValueItem
-                        {
-                            Enabled = true, 
-                            Value = $"Student{parentOrContactProperName}Association",
-                            Key = "StudentParentOrContactAssociationName"
-                        });
-                    
-                    postmanEnvironment.Values.Add(
-                        new ValueItem
-                        {
-                            Enabled = true, 
-                            Value = $"Student{parentOrContactProperName}Associations",
-                            Key = "StudentParentOrContactAssociationCollectionName"
-                        });
 
-                        var jsonString = JsonConvert.SerializeObject(
+                    var jsonString = JsonConvert.SerializeObject(
                         postmanEnvironment,
                         Formatting.Indented,
                         new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });

--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
@@ -142,7 +142,7 @@ namespace EdFi.Ods.Api.IntegrationTestHarness
                         new ValueItem
                         {
                             Enabled = true, 
-                            Value = $"{parentOrContactProperName.ToLower()}UniqueId",
+                            Value = $"{parentOrContactProperName}UniqueId",
                             Key = "ParentOrContactUniqueIdName"
                         });
                     


### PR DESCRIPTION
This allows the Postman test collection to correctly execute when the ODS runs either data standard 4.0.0 or 5.0.0. It functions be providing Postman environmental variables (in environment.json file generated by the TestHarnes. These new variables can be templated into Postman requests requiring data standard specific. 

The assertions allowing 404 responses on endpoints impacted Parent -> Contact change have also been removed from the Postman collections. This was a temporary measure and is no longer required after this update to the Postman collections.