### PR TITLE
[ODS-6065] Improved test execution logging

### DIFF
--- a/logistics/scripts/run-tests.ps1
+++ b/logistics/scripts/run-tests.ps1
@@ -36,7 +36,8 @@ foreach ($assembly in $testAssemblies) {
         $reportName = $reports + (Get-ChildItem $assembly | Select-Object -ExpandProperty Name) + ".trx"
     }
 
-    & dotnet test $assembly --logger ("trx;LogFileName=" + $reportName)
+    # Log both to file and console. With "minimal" set, only failing tests will be listed in detail in the console.
+    & dotnet test $assembly --logger ("trx;LogFileName=" + $reportName) --logger "console;verbosity=minimal" --nologo
 
     if (($LASTEXITCODE -gt 0)) {
         $testAssembliesFailedToExecute += $assembly


### PR DESCRIPTION
This command update enables display of failing tests at the console, whether run locally or in GitHub Actions.

![image](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/assets/9324390/fea498c1-d617-4433-a023-88b47d891625)
