### PR TITLE
[ODS-5443] Client Side Bulk Loader in a Container

### DIFF
--- a/.github/workflows/Docker Test.yml
+++ b/.github/workflows/Docker Test.yml
@@ -33,6 +33,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - ods-api-bulk-load-console/alpine
           - ods-api-db-admin/alpine/pgsql
           - ods-api-db-ods-minimal/alpine/pgsql
           - ods-api-db-ods-sandbox/alpine/pgsql

--- a/Docker/build-images.ps1
+++ b/Docker/build-images.ps1
@@ -73,6 +73,11 @@ param (
     [string]
     $SandboxVersion = $env:SANDBOX_VERSION,
 
+    # NuGet package version for the Ed-Fi BulkLoad Client Console application.
+    [Parameter()]
+    [string]
+    $BulkLoadVersion = $env:BULKLOAD_VERSION,
+
     # Base of the tag, which is combined with the version when tagging.
     [Parameter()]
     [string]
@@ -202,3 +207,6 @@ Invoke-Build -ImageName ods-api-web-sandbox-admin -Path alpine/mssql `
 
 Invoke-Build -ImageName ods-api-web-sandbox-admin -Path alpine/pgsql `
     -BuildArgs "--build-arg SANDBOX_VERSION=$SandboxVersion"
+
+Invoke-Build -ImageName ods-api-bulk-load-console -Path alpine `
+    -BuildArgs "--build-arg BULKLOAD_VERSION=$BulkLoadVersion"

--- a/Docker/get-versions.ps1
+++ b/Docker/get-versions.ps1
@@ -184,3 +184,4 @@ $env:SWAGGER_VERSION = "$(Get-NugetPackageVersion -PackageName EdFi.Suite3.Ods.S
 $env:SANDBOX_VERSION = "$(Get-NugetPackageVersion -PackageName EdFi.Suite3.Ods.SandboxAdmin -PackageVersion $PackageVersion -PreRelease:$PreRelease)".Trim()
 $env:STANDARD_VERSION = $StandardVersion
 $env:EXTENSION_VERSION = $ExtensionVersion
+$env:BULKLOAD_VERSION = "$(Get-NugetPackageVersion -PackageName EdFi.Suite3.BulkLoadClient.Console -PackageVersion $PackageVersion -PreRelease:$PreRelease)".Trim()

--- a/Docker/ods-api-bulk-load-console/alpine/Dockerfile
+++ b/Docker/ods-api-bulk-load-console/alpine/Dockerfile
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+# SDK image used to install dotnet tool. Runtime image do not have 'dotnet tools' installed
+FROM mcr.microsoft.com/dotnet/sdk:8.0.201-alpine3.19@sha256:e646d8a0fa589bcd970e0ebde394780398e8ae08fffeb36781753c51fc9e87b0 AS builder
+
+ARG BULKLOAD_VERSION
+
+RUN dotnet tool install -g \
+    --add-source https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json \
+    EdFi.Suite3.BulkLoadClient.Console --version $BULKLOAD_VERSION && \
+    rm -f /root/.dotnet/tools/.store/edfi.suite3.bulkloadclient.console/$BULKLOAD_VERSION/edfi.suite3.bulkloadclient.console/$BULKLOAD_VERSION/tools/net8.0/any/log4net.config
+
+# Smaller image
+FROM mcr.microsoft.com/dotnet/runtime:8.0.2-alpine3.19@sha256:17c0535218406fa12788a26925c6d31e27cb52edf94c1aa7666f33ab804b1663
+RUN apk --upgrade --no-cache add envsubst=~0 bash=~5 && \
+    addgroup -S edfi && adduser -S edfi -G edfi
+
+LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
+
+ARG BULKLOAD_VERSION
+ENV ENV_BULKLOAD_VERSION $BULKLOAD_VERSION
+ENV ENV_CONSOLE_LOG_LEVEL="INFO"
+ENV ENV_FILE_LOG_LEVEL="DEBUG"
+
+# Copy global tools from the build layer 
+COPY --from=builder --chown=edfi /root/.dotnet/tools/ /opt/bin
+
+COPY log4net.template.config /tmp/log4net.template.config
+COPY --chmod=500 --chown=edfi run.sh /usr/local/bin/run.sh
+
+# Add the tool copied from the build layer to the $PATH env variable.
+# This is done to call the BulkLoadClient without specifying the full path.
+ENV PATH="/opt/bin:${PATH}"
+
+RUN mkdir -p /var/bulkload/working /var/bulkload/log && \
+    chown -R edfi /var/bulkload
+
+USER edfi
+
+ENTRYPOINT ["/usr/local/bin/run.sh"]
+CMD ["--help"]

--- a/Docker/ods-api-bulk-load-console/alpine/Dockerfile
+++ b/Docker/ods-api-bulk-load-console/alpine/Dockerfile
@@ -15,7 +15,7 @@ RUN dotnet tool install -g \
 
 # Smaller image
 FROM mcr.microsoft.com/dotnet/runtime:8.0.2-alpine3.19@sha256:17c0535218406fa12788a26925c6d31e27cb52edf94c1aa7666f33ab804b1663
-RUN apk --upgrade --no-cache add envsubst=~0 bash=~5 && \
+RUN apk --upgrade --no-cache add gettext=~0 bash=~5 && \
     addgroup -S edfi && adduser -S edfi -G edfi
 
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"

--- a/Docker/ods-api-bulk-load-console/alpine/README.md
+++ b/Docker/ods-api-bulk-load-console/alpine/README.md
@@ -1,0 +1,64 @@
+# Ed-Fi BulkLoadClient Console
+
+Provides a docker image with BulkLoadClient Console installed as a tool.
+
+> **NOTE**
+> This image is recommended for production use.
+
+## Image Variants
+
+The only supported image at this time is an Alpine-based implementation.
+
+`edfialliance/ods-api-bulk-load-console:<version>`
+
+## Supported Environment Variables
+
+```none
+ENV_CONSOLE_LOG_LEVEL=<log level for console logs. default: INFO>
+ENV_FILE_LOG_LEVEL=<log level for file logs. default: DEBUG>
+```
+
+## BulkLoadClient Command Line Parameter Definitions
+
+ | Option       | Long Option         | Description                                                                                               |
+ |:------------:|---------------------|-----------------------------------------------------------------------------------------------------------|
+ | -b           | `--baseurl`         | The base url used to derived api, metadata, oauth, and dependency urls (e.g., http://server)              |
+ | -c           | `--connectionlimit` | Maximum concurrent connections to api                                                                     |
+ | -d           | `--data`            | Path to folder containing the data files to be submitted                                                  |
+ | -e           | `--extension`       | The extension name to download Xsd Schema files for                                                       |
+ | -f           | `--force`           | (Default: false) Force reload of metadata from metadata url                                               |
+ | -k           | `--key`             | The web API OAuth key                                                                                     |
+ | -l           | `--maxRequests`     | Max number of simultaneous API requests                                                                   |
+ | -n           | `--novalidation`    | (Default: false) Do not validate the XML document against the XSD before processing                       |
+ | -p           | `--profile`         | The name of an API profile to use (optional)                                                              |
+ | -r           | `--retries`         | The number of times to retry submitting a resource                                                        |
+ | -s           | `--secret`          | The web API OAuth secret                                                                                  |
+ | -t           | `--taskcapacity`    | Maximum concurrent tasks to be buffered                                                                   |
+ | -w           | `--working`         | Path to a writable folder containing the working files, such as the swagger metadata cache and hash cache |
+ | -z           | `--xsdmetadataurl`  | The XSD metadata url (i.e. http://server/metadata)                                                        |
+ |              | `--help`            | Display this list of options.                                                                             |
+ |              | `--include-stats`   | Include timing stats.                                                                                     |
+ |              | `--version`         | Display version information.                                                                              |
+
+## Legal Information
+
+Copyright (c) 2024 Ed-Fi Alliance, LLC and contributors.
+
+Licensed under the [Apache License, Version
+2.0]([LICENSE](https://www.apache.org/licenses/LICENSE-2.0.txt)) (the
+"License").
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+### Notice about Docker base images
+
+As with all Docker images, these likely also contain other software which may be
+under other licenses (such as Bash, etc. from the base distribution, along with
+any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to
+ensure that any use of this image complies with any relevant licenses for all
+software contained within.

--- a/Docker/ods-api-bulk-load-console/alpine/README.md
+++ b/Docker/ods-api-bulk-load-console/alpine/README.md
@@ -24,7 +24,7 @@ ENV_FILE_LOG_LEVEL=<log level for file logs. default: DEBUG>
  |:------------:|---------------------|-----------------------------------------------------------------------------------------------------------|
  | -b           | `--baseurl`         | The base url used to derived api, metadata, oauth, and dependency urls (e.g., http://server)              |
  | -c           | `--connectionlimit` | Maximum concurrent connections to api                                                                     |
- | -d           | `--data`            | Path to folder containing the data files to be submitted                                                  |
+ | -d           | `--data`            | Path to folder containing the data files to be submitted. (This will always point to /var/bulkLoad/data inside the container; a mount bind to this folder is required)                                                  |
  | -e           | `--extension`       | The extension name to download Xsd Schema files for                                                       |
  | -f           | `--force`           | (Default: false) Force reload of metadata from metadata url                                               |
  | -k           | `--key`             | The web API OAuth key                                                                                     |
@@ -34,7 +34,7 @@ ENV_FILE_LOG_LEVEL=<log level for file logs. default: DEBUG>
  | -r           | `--retries`         | The number of times to retry submitting a resource                                                        |
  | -s           | `--secret`          | The web API OAuth secret                                                                                  |
  | -t           | `--taskcapacity`    | Maximum concurrent tasks to be buffered                                                                   |
- | -w           | `--working`         | Path to a writable folder containing the working files, such as the swagger metadata cache and hash cache |
+ | -w           | `--working`         | Path to a writable folder containing the working files, such as the swagger metadata cache and hash cache. (This will always point to /var/bulkLoad/working inside the container; a mount bind to this folder is optional) |
  | -z           | `--xsdmetadataurl`  | The XSD metadata url (i.e. http://server/metadata)                                                        |
  |              | `--help`            | Display this list of options.                                                                             |
  |              | `--include-stats`   | Include timing stats.                                                                                     |

--- a/Docker/ods-api-bulk-load-console/alpine/log4net.template.config
+++ b/Docker/ods-api-bulk-load-console/alpine/log4net.template.config
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+  <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%-4timestamp %-5level %logger - %message%newline" />
+    </layout>
+    <threshold value="$ENV_CONSOLE_LOG_LEVEL" />
+  </appender>
+  <appender name="RollingAppender" type="log4net.Appender.RollingFileAppender">
+    <file value="/var/bulkload/log/logfile.txt" />
+    <appendToFile value="false" />
+    <rollingStyle value="Size" />
+    <maxSizeRollBackups value="10" />
+    <maximumFileSize value="500MB" />
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%d %t [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+    </layout>
+    <threshold value="$ENV_FILE_LOG_LEVEL" />
+  </appender>
+  <root>
+    <appender-ref ref="ConsoleAppender" />
+    <appender-ref ref="RollingAppender" />
+  </root>
+</log4net>

--- a/Docker/ods-api-bulk-load-console/alpine/run.sh
+++ b/Docker/ods-api-bulk-load-console/alpine/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+set -e
+set +x
+
+envsubst < /tmp/log4net.template.config > /opt/bin/.store/edfi.suite3.bulkloadclient.console/$ENV_BULKLOAD_VERSION/edfi.suite3.bulkloadclient.console/$ENV_BULKLOAD_VERSION/tools/net8.0/any/log4net.config 
+
+EdFi.BulkLoadClient.Console $@ -w /var/bulkload/working -d /var/bulkload/data


### PR DESCRIPTION
Image edfialliance/ods-api-bulk-load-console runs on .NET 8. Can be used as a CLI command and needs to have mounted at least the data folder pointing /var/bulkLoad/data

To test
1. Build image locally, using powershell. BulkLoad 7.2.6 was built using .NET 8

```powershell
cd Docker/ods-api-bulk-load-console/alpine
$BulkLoadVersion='7.2.6'
docker build . -t edfialliance/ods-api-bulk-load-console --build-arg BULKLOAD_VERSION=$BulkLoadVersion
```

2. Run image to verify (---help parameter is default, so this command should display a list of available options for the Bulk Load Client)
```powershell
docker run -it --rm edfialliance/ods-api-bulk-load-console
```

3. Download Sample XML Files from [here](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-Standard/tree/v5.0.0/Samples/Sample%20XML)

4. Setup a Populated Sandbox either by using initdev locally or the [Sandbox Docker Example](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Docker)

    4.1. Test using initdev Sandbox
    ```powershell
    docker run --name bulk-load-console -it --rm -d `
    -e FILE_LOG_LEVEL='WARN' `
    -v <Local path to your Sample XML data>:/var/bulkload/data `
    edfialliance/ods-api-bulk-load-console `
    -b http://host.docker.internal:<PORT>/ `
    -e tpdm `
    -k <Populated Key> `
    -s <Populated Secret> `
    -r 1 `
    -l 1 `
    -f
    ```

    4.2 Test using Docker Sandbox
    ```powershell
    docker run --name bulk-load-console -it --rm -d `
    -e FILE_LOG_LEVEL='WARN' `
    -v <Local path to your Sample XML data>:/var/bulkload/data `
    --net container:ed-fi-ods-api `
    edfialliance/ods-api-bulk-load-console `
    -b http://ed-fi-ods-api/ `
    -e tpdm `
    -k <Populated Key> `
    -s <Populated Secret> `
    -r 1 `
    -l 1 `
    -f
    ```

5. Verify the following in the container view using docker ui
    - Verify log4net.config, running the following command in the exec tab
    ```sh
    cat /opt/bin/.store/edfi.suite3.bulkloadclient.console/7.2.6/edfi.suite3.bulkloadclient.console/7.2.6/tools/net8.0/any/log4net.config
    ```
    - Verify logs created running the following command in the exec tab
    ```sh
    ls /var/bulkLoad/log
    ```
    - Verify logging 200 response codes in the logs tab