### PR TITLE
[ODS-6389] Update npgsql package - v7.1

### DIFF
--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.11" />
-    <PackageReference Include="Npgsql" Version="7.0.6" />
+    <PackageReference Include="Npgsql" Version="7.0.7" />
     <PackageReference Include="NHibernate" Version="5.4.0" />
   </ItemGroup>
 

--- a/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
+++ b/Application/EdFi.Ods.SandboxAdmin/EdFi.Ods.SandboxAdmin.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
-    <PackageReference Include="Npgsql" Version="7.0.6" />
+    <PackageReference Include="Npgsql" Version="7.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
+++ b/Application/EdFi.Ods.WebApi/EdFi.Ods.WebApi.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />    
     <PackageReference Include="NHibernate" Version="5.4.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Npgsql" Version="7.0.6" />    
+    <PackageReference Include="Npgsql" Version="7.0.7" />    
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
![image](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/assets/34613894/b5f31868-090f-4b58-80f8-6d5c231a9cab)
I tried with 8.0.3  it was throwing
Error	CS1929	'IHostBuilder' does not contain a definition for 'ConfigureLogging' and the best extension method overload 'WebHostBuilderExtensions.ConfigureLogging(IWebHostBuilder, Action<ILoggingBuilder>)' requires a receiver of type 'Microsoft.AspNetCore.Hosting.IWebHostBuilder'	

![image](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/assets/34613894/2bff293a-3244-4f07-9a8e-377e9165d4c4)
So I updated to 7.07 another patch version for this issue 


