### PR TITLE
[ODS-6434]Rebuild Database Templates build -Skip already successful package creation from working branch

### DIFF
--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -192,7 +192,20 @@ jobs:
           echo "IsSameCommitinAllthreeRepository=true" >> $Env:GITHUB_ENV
            Write-Host "IsSameCommitinAllthreeRepository is true."
         }
-
+        
+        echo "Homograph_package_alreadyupdated=false" >> $Env:GITHUB_ENV
+        echo "Sample_package_alreadyupdated=false" >> $Env:GITHUB_ENV
+        echo "TPDM_package_alreadyupdated=false" >> $Env:GITHUB_ENV
+        echo "codeGen_successful_runexist=false" >> $Env:GITHUB_ENV
+        echo "populated_template_successful_runexist=false" >> $Env:GITHUB_ENV
+        echo "populated_template_package_alreadyupdated=false" >> $Env:GITHUB_ENV
+        echo "populated_template_postgreSQL_successful_runexist=false" >> $Env:GITHUB_ENV
+        echo "populated_template_postgreSQL_package_alreadyupdated=false" >> $Env:GITHUB_ENV
+        echo "minimal_template_successful_runexist=false" >> $Env:GITHUB_ENV
+        echo "minimal_template_package_alreadyupdated=false" >> $Env:GITHUB_ENV
+        echo "minimal_template_postgreSQL_successful_runexist=false" >> $Env:GITHUB_ENV
+        echo "minimal_template_postgreSQL_package_alreadyupdated=false" >> $Env:GITHUB_ENV                                                
+ 
     - name: Upload repositories.json as an artifact
       if: success() 
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -115,7 +115,8 @@ jobs:
       working-directory: ./Ed-Fi-ODS-Implementation/ 
       shell: pwsh
       run: |
-        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/runs?branch=${{ env.current_branch }}"
+        $workflow_file_name = "Rebuild Database Templates.yml"
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
         $expectedConclusions = @('failure', 'cancelled')
         .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions $expectedConclusions -StatusEnvName 'failed_buildexists'
               
@@ -144,10 +145,9 @@ jobs:
         $branchName = "${{ env.current_branch }}"
         $sinceDate = $oneeightyDaysAgo 
         $implementationUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
-        .\build.githubactions.ps1 'AddOrUpdateRepositoriesJson' -Url $implementationUrl -RepoName 'Ed-Fi-ODS-Implementation' -StatusEnvName 'IsSameCommitinAllthreeRepository'
+        .\build.githubactions.ps1 'AddOrUpdateRepositoriesJson' -Url $implementationUrl -RepoName 'Ed-Fi-ODS-Implementation'
 
     - name: Read each repo last commit for repo Ed-Fi-ODS and stored it in repositories.json 
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
@@ -158,10 +158,9 @@ jobs:
         $branchName = "${{ env.current_branch }}"
         $sinceDate = $oneeightyDaysAgo 
         $odsUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
-        .\build.githubactions.ps1  'AddOrUpdateRepositoriesJson' -Url $odsUrl -RepoName 'Ed-Fi-ODS' -StatusEnvName 'IsSameCommitinAllthreeRepository'
+        .\build.githubactions.ps1  'AddOrUpdateRepositoriesJson' -Url $odsUrl -RepoName 'Ed-Fi-ODS'
 
     - name: Read each repo last commit for repo Ed-Fi-Extensions and stored it in repositories.json 
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
@@ -172,7 +171,29 @@ jobs:
         $branchName = "${{ env.current_branch }}"
         $sinceDate = $oneeightyDaysAgo        
         $extensionsUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
-        .\build.githubactions.ps1  'AddOrUpdateRepositoriesJson' -Url $extensionsUrl -RepoName 'Ed-Fi-Extensions' -StatusEnvName 'IsSameCommitinAllthreeRepository'
+        .\build.githubactions.ps1  'AddOrUpdateRepositoriesJson' -Url $extensionsUrl -RepoName 'Ed-Fi-Extensions'
+
+    - name: Check for IscommitChanged in repositories.json
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      shell: pwsh
+      run: |
+        $FilePath = "repositories.json"
+        
+        # Read and parse the JSON file
+        $jsonContent = Get-Content -Path $FilePath | ConvertFrom-Json
+        
+        # Check if any repository has IscommitChanged set to true
+        $isCommitChanged = $jsonContent.repositories | Where-Object { $_.IscommitChanged -eq 'true' }
+
+        if ($isCommitChanged) {
+          # Set environment variable if any repository has IscommitChanged set to true
+          echo "IsSameCommitinAllthreeRepository=true" >> $Env:GITHUB_ENV
+          Write-Host "IsSameCommitinAllthreeRepository is true."
+        } else {
+          # Optionally, you can set it to false if no repository has IscommitChanged set to true
+          echo "IsSameCommitinAllthreeRepository=false" >> $Env:GITHUB_ENV
+           Write-Host "IsSameCommitinAllthreeRepository is false."
+        }
 
     - name: Upload repositories.json as an artifact
       if: success() 

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -478,18 +478,23 @@ jobs:
         $filePath = "./configuration.packages.json"
         $config = Get-Content $filePath | ConvertFrom-Json
 
-        Write-Host "IsSameCommitinAllthreeRepository: ${{ env.IsSameCommitinAllthreeRepository }}"
+        Write-Host "IsSameCommitinAllthreeRepository: $env:IsSameCommitinAllthreeRepository"
         Write-Host "inputs.rebuildLevel: ${{ github.event.inputs.rebuildLevel }}"
-        Write-Host "Homograph_package_alreadyupdated: ${{ env.Homograph_package_alreadyupdated }}"
-        Write-Host "Sample_package_alreadyupdated: ${{ env.Sample_package_alreadyupdated }}"
-        Write-Host "TPDM_package_alreadyupdated: ${{ env.TPDM_package_alreadyupdated }}"
+        Write-Host "Homograph_package_alreadyupdated: $env:Homograph_package_alreadyupdated"
+        Write-Host "Sample_package_alreadyupdated: $env:Sample_package_alreadyupdated"
+        Write-Host "TPDM_package_alreadyupdated: $env:TPDM_package_alreadyupdated"
 
-        $isCommitNotChanged = ${{ env.IsSameCommitinAllthreeRepository }} -eq 'false'
-        $isCommitChangedAndNotUpdated = ${{ env.IsSameCommitinAllthreeRepository }} -eq 'true' -and ${{ env.Homograph_package_alreadyupdated }} -eq 'false'
+        # Evaluate conditions based on environment variables
+        $isCommitNotChanged = $env:IsSameCommitinAllthreeRepository -eq 'false'
+        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Homograph_package_alreadyupdated -eq 'false'
         $rebuildLevel = '${{ github.event.inputs.rebuildLevel }}'
         $isRebuildLevelValid = $rebuildLevel -in @('DotNetPackages', 'DatabaseTemplates')
 
-        if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
+        Write-Host "isCommitNotChanged: $isCommitNotChanged"
+        Write-Host "isCommitChangedAndNotUpdated: $isCommitChangedAndNotUpdated"
+        Write-Host "isRebuildLevelValid: $isRebuildLevelValid"
+
+        if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid)
            {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Homograph.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
@@ -499,8 +504,7 @@ jobs:
             $config.packages.'homograph'.PackageVersion = $packageversion
         }
 
-        $isCommitChangedAndNotUpdated = ${{ env.IsSameCommitinAllthreeRepository }} -eq 'true' -and ${{ env.Sample_package_alreadyupdated }} -eq 'false'
-
+        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Sample_package_alreadyupdated -eq 'false'
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Sample.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
@@ -511,7 +515,7 @@ jobs:
             $config.packages.'sample'.PackageVersion = $packageversion
         }
 
-        $isCommitChangedAndNotUpdated = ${{ env.IsSameCommitinAllthreeRepository }} -eq 'true' -and ${{ env.TPDM_package_alreadyupdated }} -eq 'false'
+        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:TPDM_package_alreadyupdated -eq 'false'
 
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
         {

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -140,10 +140,10 @@ jobs:
       shell: pwsh
       run: |
 
-        $oneeightyDaysAgo = (Get-Date).AddDays(-180).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")        
-        Write-Host "oneeightyDaysAgo Date and Time in ISO 8601 format: $oneeightyDaysAgo"
+        $oneEightyDaysAgo = (Get-Date).AddDays(-180).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")        
+        Write-Host "oneeightyDaysAgo Date and Time in ISO 8601 format: $oneEightyDaysAgo"
         $branchName = "${{ env.current_branch }}"
-        $sinceDate = $oneeightyDaysAgo 
+        $sinceDate = $oneEightyDaysAgo 
         $implementationUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
         .\build.githubactions.ps1 'CreateOrUpdateRepositoriesJson' -Url $implementationUrl -RepoName 'Ed-Fi-ODS-Implementation'
 
@@ -152,10 +152,10 @@ jobs:
       shell: pwsh
       run: |
 
-        $oneeightyDaysAgo = (Get-Date).AddDays(-180).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-        Write-Host "oneeightyDaysAgo Date and Time in ISO 8601 format: $oneeightyDaysAgo"
+        $oneEightyDaysAgo = (Get-Date).AddDays(-180).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        Write-Host "oneeightyDaysAgo Date and Time in ISO 8601 format: $oneEightyDaysAgo"
         $branchName = "${{ env.current_branch }}"
-        $sinceDate = $oneeightyDaysAgo 
+        $sinceDate = $oneEightyDaysAgo 
         $odsUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
         .\build.githubactions.ps1  'CreateOrUpdateRepositoriesJson' -Url $odsUrl -RepoName 'Ed-Fi-ODS'
 
@@ -164,10 +164,10 @@ jobs:
       shell: pwsh
       run: |
 
-        $oneeightyDaysAgo = (Get-Date).AddDays(-180).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-        Write-Host "oneeightyDaysAgo Date and Time in ISO 8601 format: $oneeightyDaysAgo"
+        $oneEightyDaysAgo = (Get-Date).AddDays(-180).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        Write-Host "oneeightyDaysAgo Date and Time in ISO 8601 format: $oneEightyDaysAgo"
         $branchName = "${{ env.current_branch }}"
-        $sinceDate = $oneeightyDaysAgo        
+        $sinceDate = $oneEightyDaysAgo        
         $extensionsUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
         .\build.githubactions.ps1  'CreateOrUpdateRepositoriesJson' -Url $extensionsUrl -RepoName 'Ed-Fi-Extensions'
 
@@ -222,7 +222,7 @@ jobs:
         $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
         .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'codeGen_successful_runexist'
   
-    - name: Compare already configuration.packages.json updated with EdFi.Ods.CodeGen package Version
+    - name: Check if configuration.packages.json has an updated EdFi.Ods.CodeGen package version
       working-directory: ./Ed-Fi-ODS-Implementation/    
       if: ${{ env.codeGen_successful_runexist == 'true' }}    
       shell: pwsh
@@ -326,7 +326,7 @@ jobs:
         $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
         .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'Homograph_successful_runexist'
   
-    - name: Compare already configuration.packages.json updated with EdFi.Ods.Extensions.Homograph package Version
+    - name: Check if configuration.packages.json has an updated EdFi.Ods.Extensions.Homograph package Version
       working-directory: ./Ed-Fi-ODS-Implementation/
       if: ${{ env.Homograph_successful_runexist == 'true' }}
       shell: pwsh
@@ -342,7 +342,7 @@ jobs:
         $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
         .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'Sample_successful_runexist'
   
-    - name: Compare already configuration.packages.json updated with EdFi.Ods.Extensions.Sample package Version
+    - name: Check if configuration.packages.json has an updated EdFi.Ods.Extensions.Sample package Version
       working-directory: ./Ed-Fi-ODS-Implementation/
       if: ${{ env.Sample_successful_runexist == 'true' }}
       shell: pwsh

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -466,14 +466,15 @@ jobs:
         $config = Get-Content $filePath | ConvertFrom-Json
 
         Write-Host "IsSameCommitinAllthreeRepository: ${{ env.IsSameCommitinAllthreeRepository }}"
-        Write-Host "inputs_rebuildLevel: ${{ github.event.inputs.inputs_rebuildLevel }}"
+        Write-Host "inputs.rebuildLevel: ${{ github.event.inputs.rebuildLevel }}"
         Write-Host "Homograph_package_alreadyupdated: ${{ env.Homograph_package_alreadyupdated }}"
         Write-Host "Sample_package_alreadyupdated: ${{ env.Sample_package_alreadyupdated }}"
         Write-Host "TPDM_package_alreadyupdated: ${{ env.TPDM_package_alreadyupdated }}"
 
         $isCommitNotChanged = ${{ env.IsSameCommitinAllthreeRepository }} -eq 'false'
         $isCommitChangedAndNotUpdated = ${{ env.IsSameCommitinAllthreeRepository }} -eq 'true' -and ${{ env.Homograph_package_alreadyupdated }} -eq 'false'
-        $isRebuildLevelValid = ${{ github.event.inputs.inputs_rebuildLevel }} -in @('DotNetPackages', 'DatabaseTemplates')
+        $rebuildLevel = '${{ github.event.inputs.rebuildLevel }}'
+        $isRebuildLevelValid = $rebuildLevel -in @('DotNetPackages', 'DatabaseTemplates')
 
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
            {

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -291,7 +291,8 @@ jobs:
           $filePath = "./configuration.packages.json"
 
           # Check if there are any changes in the file
-          $changesDetected = git diff --quiet $filePath; $LASTEXITCODE -eq 1
+          git diff --quiet $filePath
+          $changesDetected = $LASTEXITCODE -eq 1
 
           if ($changesDetected) {
               Write-Host "Changes detected in configuration.packages.json. Committing and pushing."
@@ -301,6 +302,7 @@ jobs:
           } else {
               Write-Host "No changes detected in configuration.packages.json. Skipping commit."
           }
+          exit 0
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Extensions.Homograph.yml
       working-directory: ./Ed-Fi-ODS-Implementation/
       if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
@@ -500,7 +502,8 @@ jobs:
           $filePath = "./configuration.packages.json"
 
           # Check if there are any changes in the file
-          $changesDetected = git diff --quiet $filePath; $LASTEXITCODE -eq 1
+          git diff --quiet $filePath
+          $changesDetected = $LASTEXITCODE -eq 1
 
           if ($changesDetected) {
               Write-Host "Changes detected in configuration.packages.json. Committing and pushing."
@@ -510,7 +513,7 @@ jobs:
           } else {
               Write-Host "No changes detected in configuration.packages.json. Skipping commit."
           }
-
+          exit 0
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Populated.Template.yml
       working-directory: ./Ed-Fi-ODS-Implementation/
       if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
@@ -772,7 +775,8 @@ jobs:
           $filePath = "./configuration.packages.json"
 
           # Check if there are any changes in the file
-          $changesDetected = git diff --quiet $filePath; $LASTEXITCODE -eq 1
+          git diff --quiet $filePath
+          $changesDetected = $LASTEXITCODE -eq 1
 
           if ($changesDetected) {
               Write-Host "Changes detected in configuration.packages.json. Committing and pushing."
@@ -782,7 +786,7 @@ jobs:
           } else {
               Write-Host "No changes detected in configuration.packages.json. Skipping commit."
           }
-
+          exit 0
     - name: Dispatch EdFi.Ods.Populated.Template.TPDM  workflow
       if: inputs.rebuildLevel == 'DatabaseTemplates'
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -187,12 +187,12 @@ jobs:
 
         if ($isCommitChanged) {
           # Set environment variable if any repository has IscommitChanged set to true
-          echo "IsSameCommitinAllthreeRepository=true" >> $Env:GITHUB_ENV
-          Write-Host "IsSameCommitinAllthreeRepository is true."
+          echo "IsSameCommitinAllthreeRepository=false" >> $Env:GITHUB_ENV
+          Write-Host "IsSameCommitinAllthreeRepository is false."
         } else {
           # Optionally, you can set it to false if no repository has IscommitChanged set to true
-          echo "IsSameCommitinAllthreeRepository=false" >> $Env:GITHUB_ENV
-           Write-Host "IsSameCommitinAllthreeRepository is false."
+          echo "IsSameCommitinAllthreeRepository=true" >> $Env:GITHUB_ENV
+           Write-Host "IsSameCommitinAllthreeRepository is true."
         }
 
     - name: Upload repositories.json as an artifact

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -426,8 +426,7 @@ jobs:
         repo: Ed-Fi-Alliance-OSS/Ed-Fi-Extensions
         check_artifacts: true
 
-    - name: Update configuration.packages.json with all Extensions Homograph ,TPDM , Sample new package version
-      if: ${{ (env.Homograph_package_alreadyupdated == 'false' || env.Sample_package_alreadyupdated == 'false' || env.Homograph_package_alreadyupdated == 'false') && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates') }}
+    - name: Update configuration.packages.json with all Extensions Homograph, TPDM, Sample new package version
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
@@ -435,45 +434,50 @@ jobs:
         $filePath = "./configuration.packages.json"
         $config = Get-Content $filePath | ConvertFrom-Json
 
-        if ($env:Homograph_package_alreadyupdated -eq 'false' )
-        {
+        if (($env:IsSameCommitinAllthreeRepository -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates')) -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Homograph_package_alreadyupdated -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates'))){
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Homograph.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
             $newRevision =$folderParts[$folderParts.Count- 2]
-            $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
+            $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision"
             Write-Host "Extensions.Homograph latestVersion"  $packageversion
             $config.packages.'homograph'.PackageVersion = $packageversion
         }
 
-        if ($env:Sample_package_alreadyupdated -eq 'false' )
-        {
+        if (($env:IsSameCommitinAllthreeRepository -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates')) -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Sample_package_alreadyupdated -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates'))){
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Sample.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
             $newRevision =$folderParts[$folderParts.Count- 2]
-            $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
+            $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision"
             Write-Host "Extensions.Sample latestVersion"  $packageversion
             $config.packages.'sample'.PackageVersion = $packageversion
         }
 
-        if ($env:TPDM_package_alreadyupdated -eq 'false' )
-        {
-          $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.TPDM.Core.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
-          $folderParts = $packageFolder -split "\."
-          $newRevision =$folderParts[$folderParts.Count- 2]
-          $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
-          Write-Host " Extensions.TPDM latestVersion"  $packageversion
-          $config.packages.'tpdm'.PackageVersion = $packageversion
+        if (($env:IsSameCommitinAllthreeRepository -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates')) -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:TPDM_package_alreadyupdated -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates'))){
+            $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.TPDM.Core.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
+            $folderParts = $packageFolder -split "\."
+            $newRevision =$folderParts[$folderParts.Count- 2]
+            $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision"
+            Write-Host "Extensions.TPDM latestVersion"  $packageversion
+            $config.packages.'tpdm'.PackageVersion = $packageversion
         }
 
         $config | ConvertTo-Json | Format-Json | Out-File -FilePath $filePath -Encoding UTF8
 
     - name: Commit and push updated Extensions- TPDM, Sample, Homograph package references
-      if: ${{ (env.Homograph_package_alreadyupdated == 'false' || env.Sample_package_alreadyupdated == 'false' || env.Homograph_package_alreadyupdated == 'false') && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates') }}
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-        git add ./configuration.packages.json
-        git commit -m "Updating for new Extensions- TPDM, Sample, Homograph package version"
-        git push -u origin ${{ env.current_branch }}
+          # Check if there are any changes in the configuration.packages.json file
+          git diff --quiet ./configuration.packages.json
+
+          # $? holds the exit code of the last executed command
+          if (-not $?) {
+            Write-Host "No changes detected in configuration.packages.json. Skipping commit."
+          } else {
+            Write-Host "Changes detected in configuration.packages.json. Committing and pushing."
+            git add ./configuration.packages.json
+            git commit -m "Updating for new Extensions- TPDM, Sample, Homograph package version"
+            git push -u origin ${{ env.current_branch }}
+          }
 
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Populated.Template.yml
       working-directory: ./Ed-Fi-ODS-Implementation/
@@ -680,7 +684,6 @@ jobs:
         check_artifacts: true
 
     - name: Update configuration.packages.json with all EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL new package version
-      if: ${{ ((env.minimal_template_postgreSQL_package_alreadyupdated == 'false' || env.populated_template_postgreSQL_package_alreadyupdated == 'false' || env.populated_template_package_alreadyupdated == 'false' || env.minimal_template_postgreSQL_package_alreadyupdated == 'false') && ( inputs.rebuildLevel == 'DatabaseTemplates')) }}
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
@@ -688,7 +691,7 @@ jobs:
         $filePath = "./configuration.packages.json"
         $config = Get-Content $filePath | ConvertFrom-Json
 
-        if ($env:minimal_template_package_alreadyupdated -eq 'false' )
+        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')) -or (($env:IsSameCommitinAllthreeRepository -eq 'true') -and ($env:minimal_template_package_alreadyupdated -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates'))) 
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Minimal.Template.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
@@ -698,7 +701,7 @@ jobs:
             $config.packages.'EdFiMinimalTemplate'.PackageVersion = $packageversion
         }
 
-        if ($env:minimal_template_postgreSQL_package_alreadyupdated -eq 'false' )
+        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')) -or (($env:IsSameCommitinAllthreeRepository -eq 'true') -and ($env:populated_template_package_alreadyupdated -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')))
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Minimal.Template.PostgreSQL.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
@@ -708,7 +711,7 @@ jobs:
             $config.packages.'PostgreSqlMinimalTemplate'.PackageVersion = $packageversion
         }
 
-        if ($env:populated_template_package_alreadyupdated -eq 'false' )
+        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')) -or (($env:IsSameCommitinAllthreeRepository -eq 'true') -and ($env:populated_template_package_alreadyupdated -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')))
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Populated.Template.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
@@ -718,7 +721,7 @@ jobs:
             $config.packages.'GrandBend'.PackageVersion = $packageversion
         }
 
-        if ($env:populated_template_postgreSQL_package_alreadyupdated -eq 'false' )
+        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')) -or (($env:IsSameCommitinAllthreeRepository -eq 'true') -and ($env:populated_template_postgreSQL_package_alreadyupdated -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')))
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Populated.Template.PostgreSQL.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
@@ -730,12 +733,21 @@ jobs:
         $config | ConvertTo-Json | Format-Json | Out-File -FilePath $filePath -Encoding UTF8
 
     - name: Commit and push updated EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL new package version
-      if: ${{ ( env.minimal_template_package_alreadyupdated == 'false' || env.minimal_template_postgreSQL_package_alreadyupdated == 'false' || env.populated_template_package_alreadyupdated == 'false' || env.populated_template_postgreSQL_package_alreadyupdated == 'false') && ( inputs.rebuildLevel == 'DatabaseTemplates') }}
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-        git add ./configuration.packages.json
-        git commit -m "Updating for new EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL package version"
-        git push -u origin ${{ env.current_branch }}
+
+          # Check if there are any changes in the configuration.packages.json file
+          git diff --quiet ./configuration.packages.json
+
+          # $? holds the exit code of the last executed command
+          if (-not $?) {
+            Write-Host "No changes detected in configuration.packages.json. Skipping commit."
+          } else {
+            Write-Host "Changes detected in configuration.packages.json. Committing and pushing."
+            git add ./configuration.packages.json
+            git commit -m "Updating for new EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL package version"
+            git push -u origin ${{ env.current_branch }}
+          }        
 
     - name: Dispatch EdFi.Ods.Populated.Template.TPDM  workflow
       if: inputs.rebuildLevel == 'DatabaseTemplates'

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -285,6 +285,7 @@ jobs:
 
     - name: Commit and push updated EdFi.Ods.CodeGen package reference
       working-directory: ./Ed-Fi-ODS-Implementation/
+      shell: pwsh
       run: |
           # Define the file path
           $filePath = "./configuration.packages.json"
@@ -493,6 +494,7 @@ jobs:
 
     - name: Commit and push updated Extensions- TPDM, Sample, Homograph package references
       working-directory: ./Ed-Fi-ODS-Implementation/
+      shell: pwsh      
       run: |
           # Define the file path
           $filePath = "./configuration.packages.json"
@@ -764,6 +766,7 @@ jobs:
 
     - name: Commit and push updated EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL new package version
       working-directory: ./Ed-Fi-ODS-Implementation/
+      shell: pwsh      
       run: |
           # Define the file path
           $filePath = "./configuration.packages.json"

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -55,31 +55,36 @@ jobs:
       contents: write
 
     steps:
+
     - name: Extract StandardVersion
       id: extract_version
-      run: echo "standard_version=${{ fromJson(needs.FindStandardAndExtensionVersions.outputs.StandardVersions)[0] }}" >> $GITHUB_ENV
+      run: echo "standard_version=4.0.0" >> $GITHUB_ENV
     - name: Checkout Ed-Fi-ODS-Implementation
       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
           path: Ed-Fi-ODS-Implementation/
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
+
     - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
             .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "."
+
     - name: Checkout Ed-Fi-ODS
       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
       with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
           path: Ed-Fi-ODS/
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
+
     - name: Is pull request branch exists in Ed-Fi-ODS
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
            .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"
+
     - name: Set Current Branch Environment Variable
       shell: pwsh
       run: |
@@ -88,8 +93,112 @@ jobs:
           $current_branch = '${{env.HEAD_REF}}'
         }
         Write-Host "Current Branch: $current_branch"   
-        echo "current_branch=$current_branch" >> $Env:GITHUB_ENV                   
+        echo "current_branch=$current_branch" >> $Env:GITHUB_ENV
+        if ($current_branch -eq 'main') {
+          Write-Host "Current branch is main. Stopping the build."
+          exit 1
+        }
+
+    - name: Check ${{ env.current_branch }} branch exists in all 3 repositories or not 
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      shell: pwsh
+      run: |
+
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/branches/${{ env.current_branch }}"
+        .\build.githubactions.ps1  TestBranchExists -RepoName "Ed-Fi-ODS-Implementation" -BranchName "${{ env.current_branch }}" -Url $url
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/branches/${{ env.current_branch }}"
+        .\build.githubactions.ps1  TestBranchExists -RepoName "Ed-Fi-ODS" -BranchName "${{ env.current_branch }}" -Url $url
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/branches/${{ env.current_branch }}"
+        .\build.githubactions.ps1  TestBranchExists -RepoName "Ed-Fi-Extensions" -BranchName "${{ env.current_branch }}" -Url $url
+
+    - name: Check any failed previous Workflow Run exist in current branch
+      working-directory: ./Ed-Fi-ODS-Implementation/ 
+      shell: pwsh
+      run: |
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/runs?branch=${{ env.current_branch }}"
+        $expectedConclusions = @('failure', 'cancelled')
+        .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions $expectedConclusions -StatusEnvName 'failed_buildexists'
+              
+    - name: Download repositories.json from last run
+      if: ${{ env.failed_buildexists == 'true' }}
+      uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
+      with:
+        workflow: Rebuild Database Templates.yml
+        name: repositories-json
+        workflow_conclusion: ("failure","cancelled")
+        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/
+        run_id: ${{  env.rebuild_database_templates_lastrunId }}
+        repo: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
+        check_artifacts: true
+        allow_forks: false
+        if_no_artifact_found: ignore
+      continue-on-error: true
+
+    - name: Read each repo last commit for repo Ed-Fi-ODS-Implementation and stored it in repositories.json 
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      shell: pwsh
+      run: |
+
+        $oneeightyDaysAgo = (Get-Date).AddDays(-180).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")        
+        Write-Host "oneeightyDaysAgo Date and Time in ISO 8601 format: $oneeightyDaysAgo"
+        $branchName = "${{ env.current_branch }}"
+        $sinceDate = $oneeightyDaysAgo 
+        $implementationUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
+        .\build.githubactions.ps1 'AddOrUpdateRepositoriesJson' -Url $implementationUrl -RepoName 'Ed-Fi-ODS-Implementation' -StatusEnvName 'IsSameCommitinAllthreeRepository'
+
+    - name: Read each repo last commit for repo Ed-Fi-ODS and stored it in repositories.json 
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      shell: pwsh
+      run: |
+        Write-Host "IsSameCommitinAllthreeRepository is ${{ env.IsSameCommitinAllthreeRepository }}"
+
+        $oneeightyDaysAgo = (Get-Date).AddDays(-180).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        Write-Host "oneeightyDaysAgo Date and Time in ISO 8601 format: $oneeightyDaysAgo"
+        $branchName = "${{ env.current_branch }}"
+        $sinceDate = $oneeightyDaysAgo 
+        $odsUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
+        .\build.githubactions.ps1  'AddOrUpdateRepositoriesJson' -Url $odsUrl -RepoName 'Ed-Fi-ODS' -StatusEnvName 'IsSameCommitinAllthreeRepository'
+
+    - name: Read each repo last commit for repo Ed-Fi-Extensions and stored it in repositories.json 
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      shell: pwsh
+      run: |
+        Write-Host "IsSameCommitinAllthreeRepository is ${{ env.IsSameCommitinAllthreeRepository }}"
+
+        $oneeightyDaysAgo = (Get-Date).AddDays(-180).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        Write-Host "oneeightyDaysAgo Date and Time in ISO 8601 format: $oneeightyDaysAgo"
+        $branchName = "${{ env.current_branch }}"
+        $sinceDate = $oneeightyDaysAgo        
+        $extensionsUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
+        .\build.githubactions.ps1  'AddOrUpdateRepositoriesJson' -Url $extensionsUrl -RepoName 'Ed-Fi-Extensions' -StatusEnvName 'IsSameCommitinAllthreeRepository'
+
+    - name: Upload repositories.json as an artifact
+      if: success() 
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+      with:
+        name: repositories-json
+        path: ${{ github.workspace }}/Ed-Fi-ODS-Implementation/repositories.json
+ 
+    - name: Check if any successful workflow run in Pkg EdFi.Ods.CodeGen.yml
+      working-directory: ./Ed-Fi-ODS-Implementation/     
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      shell: pwsh
+      run: |
+        $workflow_file_name = "Pkg EdFi.Ods.CodeGen.yml"
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
+        .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'codeGen_successful_runexist'
+  
+    - name: Compare already configuration.packages.json updated with EdFi.Ods.CodeGen package Version
+      working-directory: ./Ed-Fi-ODS-Implementation/    
+      if: ${{ env.codeGen_successful_runexist == 'true' }}    
+      shell: pwsh
+      run: |
+        .\build.githubactions.ps1  'ComparePackageVersions' -PackageName 'EdFi.Ods.CodeGen' -StatusEnvName 'EdFi.Ods.CodeGen_package_alreadyupdated'
+
     - name: Dispatch EdFi.Ods.CodeGen workflow
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'false' || (env.IsSameCommitinAllthreeRepository == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_codegen
       with:
@@ -99,7 +208,9 @@ jobs:
         owner: ${{ github.repository_owner }}
         workflow: Pkg EdFi.Ods.CodeGen.yml
         workflow_timeout_seconds: 4800
+
     - name: Await to complete the execution for EdFi.Ods.CodeGen RunID ${{ steps.return_dispatch_codegen.outputs.run_id }}
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'false' || (env.IsSameCommitinAllthreeRepository == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -110,6 +221,7 @@ jobs:
         poll_interval_ms: 5000
         
     - name: Download Codegen artifact using Run Id ${{ steps.return_dispatch_codegen.outputs.run_id }}
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'false' || (env.IsSameCommitinAllthreeRepository == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.CodeGen.yml
@@ -119,6 +231,7 @@ jobs:
         run_id: ${{ steps.return_dispatch_codegen.outputs.run_id }}
         repo: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
         check_artifacts: true
+
     - name: Import GPG key
       id: import-gpg
       uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6.0.0
@@ -128,12 +241,15 @@ jobs:
         passphrase: ${{ secrets.EDFIBUILDAGENT_PASSPHRASE }}
         git_user_signingkey: true
         git_commit_gpgsign: true
+
     - name: Git setup
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
         git config user.name "${{ steps.import-gpg.outputs.name }}"
         git config user.email "${{ steps.import-gpg.outputs.email }}"
-    - name: update configuration.packages.json with EdFi.Ods.CodeGen new package version
+
+    - name: Update configuration.packages.json with EdFi.Ods.CodeGen new package version
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'false' || (env.IsSameCommitinAllthreeRepository == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}  
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
@@ -147,15 +263,66 @@ jobs:
         $config = Get-Content $filePath | ConvertFrom-Json
         $config.packages.'EdFi.Ods.CodeGen'.PackageVersion = $packageversion
         $config | ConvertTo-Json | Format-Json | Out-File -FilePath $filePath -Encoding UTF8
+
     - name: Commit and push updated EdFi.Ods.CodeGen package reference
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'false' || (env.IsSameCommitinAllthreeRepository == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}    
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
         git add ./configuration.packages.json
         git commit -m "Updating for new CodeGen version"
         git push -u origin ${{ env.current_branch }}
 
+    - name: Check if any successful workflow run in Pkg EdFi.Ods.Extensions.Homograph.yml
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      shell: pwsh
+      run: |
+
+        $workflow_file_name = "Pkg EdFi.Ods.Extensions.Homograph.yml"
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
+        .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'Homograph_successful_runexist'
+  
+    - name: Compare already configuration.packages.json updated with EdFi.Ods.Extensions.Homograph package Version
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.Homograph_successful_runexist == 'true' }}
+      shell: pwsh
+      run: |
+        .\build.githubactions.ps1  'ComparePackageVersions' -PackageName 'homograph' -StatusEnvName 'Homograph_package_alreadyupdated'
+
+    - name: Check if any successful workflow run in Pkg EdFi.Ods.Extensions.Sample.yml
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      shell: pwsh
+      run: |
+        $workflow_file_name = "Pkg EdFi.Ods.Extensions.Sample.yml"
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
+        .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'Sample_successful_runexist'
+  
+    - name: Compare already configuration.packages.json updated with EdFi.Ods.Extensions.Sample package Version
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.Sample_successful_runexist == 'true' }}
+      shell: pwsh
+      run: |
+        .\build.githubactions.ps1  'ComparePackageVersions' -PackageName 'sample' -StatusEnvName 'Sample_package_alreadyupdated'
+
+    - name: Check if any successful workflow run in Pkg EdFi.Ods.Extensions.TPDM.yml
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      shell: pwsh
+      run: |
+        $workflow_file_name = "Pkg EdFi.Ods.Extensions.TPDM.yml"
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
+        .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'TPDM_successful_runexist'
+  
+    - name: Compare already configuration.packages.json updated with EdFi.Ods.Extensions.TPDM package Version
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.TPDM_successful_runexist == 'true' }}
+      shell: pwsh
+      run: |
+        .\build.githubactions.ps1  'ComparePackageVersions' -PackageName 'tpdm' -StatusEnvName 'TPDM_package_alreadyupdated'
+
     - name: Dispatch EdFi.Ods.Extensions.Homograph workflow
-      if: inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Homograph_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_homograph
       with:
@@ -167,7 +334,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Dispatch  EdFi.Ods.Extensions.Sample workflow
-      if: inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Sample_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_sample
       with:
@@ -179,7 +346,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Dispatch  EdFi.Ods.Extensions.TPDM worflow
-      if: inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.TPDM_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_TPDM
       with:
@@ -191,7 +358,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Await to complete the execution for EdFi.Ods.Extensions.Homograph RunID ${{ steps.return_dispatch_homograph.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Homograph_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -202,7 +369,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Await to complete the execution for EdFi.Ods.Extensions.Sample RunID ${{ steps.return_dispatch_sample.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Sample_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -213,7 +380,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Await to complete the execution for EdFi.Ods.Extensions.TPDM RunID ${{ steps.return_dispatch_TPDM.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.TPDM_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -224,7 +391,7 @@ jobs:
         poll_interval_ms: 5000
        
     - name: Download EdFi.Ods.Extensions.Homograph artifact using Run Id ${{ steps.return_dispatch_homograph.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Homograph_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}            
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Extensions.Homograph.yml
@@ -236,7 +403,7 @@ jobs:
         check_artifacts: true
 
     - name: Download EdFi.Ods.Extensions.Sample artifact using Run Id ${{ steps.return_dispatch_sample.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Sample_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}            
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Extensions.Sample.yml
@@ -248,7 +415,7 @@ jobs:
         check_artifacts: true
 
     - name: Download EdFi.Ods.Extensions.TPDM artifact using Run Id ${{ steps.return_dispatch_TPDM.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.TPDM_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Extensions.TPDM.yml
@@ -259,46 +426,121 @@ jobs:
         repo: Ed-Fi-Alliance-OSS/Ed-Fi-Extensions
         check_artifacts: true
 
-    - name: update configuration.packages.json with all Extensions Homograph ,TPDM , Sample new package version
-      if: inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'
+    - name: Update configuration.packages.json with all Extensions Homograph ,TPDM , Sample new package version
+      if: ${{ (env.Homograph_package_alreadyupdated == 'false' || env.Sample_package_alreadyupdated == 'false' || env.Homograph_package_alreadyupdated == 'false') && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates') }}
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-        $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Homograph.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
-        $folderParts = $packageFolder -split "\."
-        $newRevision =$folderParts[$folderParts.Count- 2]
-        $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
-        Write-Host "Extensions.Homograph latestVersion"  $packageversion
         Import-Module "./logistics/scripts/modules/settings/settings-management.psm1"
         $filePath = "./configuration.packages.json"
         $config = Get-Content $filePath | ConvertFrom-Json
-        $config.packages.'homograph'.PackageVersion = $packageversion
 
-        $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Sample.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
-        $folderParts = $packageFolder -split "\."
-        $newRevision =$folderParts[$folderParts.Count- 2]
-        $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
-        Write-Host "Extensions.Sample latestVersion"  $packageversion
-        $config.packages.'sample'.PackageVersion = $packageversion
+        if ($env:Homograph_package_alreadyupdated -eq 'false' )
+        {
+            $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Homograph.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
+            $folderParts = $packageFolder -split "\."
+            $newRevision =$folderParts[$folderParts.Count- 2]
+            $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
+            Write-Host "Extensions.Homograph latestVersion"  $packageversion
+            $config.packages.'homograph'.PackageVersion = $packageversion
+        }
 
-        $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.TPDM.Core.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
-        $folderParts = $packageFolder -split "\."
-        $newRevision =$folderParts[$folderParts.Count- 2]
-        $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
-        Write-Host " Extensions.TPDM latestVersion"  $packageversion
-        $config.packages.'tpdm'.PackageVersion = $packageversion
+        if ($env:Sample_package_alreadyupdated -eq 'false' )
+        {
+            $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Sample.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
+            $folderParts = $packageFolder -split "\."
+            $newRevision =$folderParts[$folderParts.Count- 2]
+            $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
+            Write-Host "Extensions.Sample latestVersion"  $packageversion
+            $config.packages.'sample'.PackageVersion = $packageversion
+        }
+
+        if ($env:TPDM_package_alreadyupdated -eq 'false' )
+        {
+          $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.TPDM.Core.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
+          $folderParts = $packageFolder -split "\."
+          $newRevision =$folderParts[$folderParts.Count- 2]
+          $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
+          Write-Host " Extensions.TPDM latestVersion"  $packageversion
+          $config.packages.'tpdm'.PackageVersion = $packageversion
+        }
 
         $config | ConvertTo-Json | Format-Json | Out-File -FilePath $filePath -Encoding UTF8
+
     - name: Commit and push updated Extensions- TPDM, Sample, Homograph package references
-      if: inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (env.Homograph_package_alreadyupdated == 'false' || env.Sample_package_alreadyupdated == 'false' || env.Homograph_package_alreadyupdated == 'false') && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates') }}
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
         git add ./configuration.packages.json
         git commit -m "Updating for new Extensions- TPDM, Sample, Homograph package version"
         git push -u origin ${{ env.current_branch }}
 
-    - name: Dispatch EdFi.Ods.Populated.Template  workflow
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+    - name: Check if any successful workflow run in Pkg EdFi.Ods.Populated.Template.yml
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      shell: pwsh
+      run: |
+        $workflow_file_name = "Pkg EdFi.Ods.Populated.Template.yml"
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
+        .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'populated_template_successful_runexist'
+  
+    - name: Compare already configuration.packages.json updated with EdFi.Ods.Populated.Template package Version
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.populated_template_successful_runexist == 'true' }}
+      shell: pwsh
+      run: |
+        .\build.githubactions.ps1  'ComparePackageVersions' -PackageName 'GrandBend' -StatusEnvName 'populated_template_package_alreadyupdated'
+
+    - name: Check if any successful workflow run in Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      shell: pwsh
+      run: |
+        $workflow_file_name = "Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml"
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
+        .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'populated_template_postgreSQL_successful_runexist'
+  
+    - name: Compare already configuration.packages.json updated with EdFi.Ods.Populated.Template.PostgreSQL package Version
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.populated_template_postgreSQL_successful_runexist == 'true' }}
+      shell: pwsh
+      run: |
+        .\build.githubactions.ps1  'ComparePackageVersions' -PackageName 'PostgreSqlPopulatedTemplate' -StatusEnvName 'populated_template_postgreSQL_package_alreadyupdated'
+
+    - name: Check if any successful workflow run in Pkg EdFi.Ods.Minimal.Template.yml
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      shell: pwsh
+      run: |
+        $workflow_file_name = "Pkg EdFi.Ods.Minimal.Template.yml"
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
+        .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'minimal_template_successful_runexist'
+  
+    - name: Compare already configuration.packages.json updated with EdFi.Ods.Minimal.Template package Version
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.minimal_template_successful_runexist == 'true' }}
+      shell: pwsh
+      run: |
+        .\build.githubactions.ps1  'ComparePackageVersions' -PackageName 'EdFiMinimalTemplate' -StatusEnvName 'minimal_template_package_alreadyupdated'
+
+    - name: Check if any successful workflow run in Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      shell: pwsh
+      run: |
+        $workflow_file_name = "Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml"
+        $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
+        .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'minimal_template_postgreSQL_successful_runexist'
+  
+    - name: Compare already configuration.packages.json updated with EdFi.Ods.Minimal.Template.PostgreSQL package Version
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      if: ${{ env.minimal_template_postgreSQL_successful_runexist == 'true' }}
+      shell: pwsh
+      run: |
+        .\build.githubactions.ps1  'ComparePackageVersions' -PackageName 'PostgreSqlMinimalTemplate' -StatusEnvName 'minimal_template_postgreSQL_package_alreadyupdated'
+
+    - name: Dispatch EdFi.Ods.Populated.Template workflow
+      if: ${{ ((env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_populated_template
       with:
@@ -310,7 +552,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Dispatch EdFi.Ods.Populated.Template.PostgreSQL workflow
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_populated_template_postgresql
       with:
@@ -322,7 +564,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Dispatch EdFi.Ods.Minimal.Template  workflow
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_minimal_template
       with:
@@ -334,7 +576,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Dispatch EdFi.Ods.Minimal.Template.PostgreSQL  workflow
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_minimal_template_postgresql
       with:
@@ -346,7 +588,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Await to complete the execution for EdFi.Ods.Minimal.Template.PostgreSQL RunID ${{ steps.return_dispatch_minimal_template_postgresql.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -357,7 +599,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Await to complete the execution for EdFi.Ods.Minimal.Template RunID ${{ steps.return_dispatch_minimal_template.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -368,7 +610,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Await to complete the execution for EdFi.Ods.Populated.Template RunID ${{ steps.return_dispatch_populated_template.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -379,7 +621,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Await to complete the execution for EdFi.Ods.Populated.Template.PostgreSQL RunID ${{ steps.return_dispatch_populated_template_postgresql.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -390,7 +632,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Download EdFi.Ods.Minimal.Template artifact using Run Id ${{ steps.return_dispatch_minimal_template.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Minimal.Template.yml
@@ -402,7 +644,7 @@ jobs:
         check_artifacts: true
 
     - name: Download EdFi.Ods.Minimal.Template.PostgreSQL artifact using Run Id ${{ steps.return_dispatch_minimal_template_postgresql.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
@@ -414,7 +656,7 @@ jobs:
         check_artifacts: true
 
     - name: Download EdFi.Ods.Populated.Template artifact using Run Id ${{ steps.return_dispatch_populated_template.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Populated.Template.yml
@@ -426,7 +668,7 @@ jobs:
         check_artifacts: true
 
     - name: Download EdFi.Ods.Populated.Template.PostgreSQL artifact using Run Id ${{ steps.return_dispatch_populated_template_postgresql.outputs.run_id }}
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
@@ -437,51 +679,62 @@ jobs:
         run_id: ${{ steps.return_dispatch_populated_template_postgresql.outputs.run_id }}
         check_artifacts: true
 
-
-    - name: update configuration.packages.json with all EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL new package version
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+    - name: Update configuration.packages.json with all EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL new package version
+      if: ${{ ((env.minimal_template_postgreSQL_package_alreadyupdated == 'false' || env.populated_template_postgreSQL_package_alreadyupdated == 'false' || env.populated_template_package_alreadyupdated == 'false' || env.minimal_template_postgreSQL_package_alreadyupdated == 'false') && ( inputs.rebuildLevel == 'DatabaseTemplates')) }}
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-        $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Minimal.Template.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
-        $folderParts = $packageFolder -split "\."
-        $newRevision =$folderParts[$folderParts.Count- 2]
-        $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
-        Write-Host "EdFi.Suite3.Ods.Minimal.Template latestVersion"  $packageversion
         Import-Module "./logistics/scripts/modules/settings/settings-management.psm1"
         $filePath = "./configuration.packages.json"
         $config = Get-Content $filePath | ConvertFrom-Json
-        $config.packages.'EdFiMinimalTemplate'.PackageVersion = $packageversion
 
-        $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Minimal.Template.PostgreSQL.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
-        $folderParts = $packageFolder -split "\."
-        $newRevision =$folderParts[$folderParts.Count- 2]
-        $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
-        Write-Host "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL latestVersion"  $packageversion
-        $config.packages.'PostgreSqlMinimalTemplate'.PackageVersion = $packageversion
+        if ($env:minimal_template_package_alreadyupdated -eq 'false' )
+        {
+            $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Minimal.Template.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
+            $folderParts = $packageFolder -split "\."
+            $newRevision =$folderParts[$folderParts.Count- 2]
+            $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
+            Write-Host "EdFi.Suite3.Ods.Minimal.Template latestVersion"  $packageversion
+            $config.packages.'EdFiMinimalTemplate'.PackageVersion = $packageversion
+        }
 
-        $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Populated.Template.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
-        $folderParts = $packageFolder -split "\."
-        $newRevision =$folderParts[$folderParts.Count- 2]
-        $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
-        Write-Host " EdFi.Suite3.Ods.Populated.Template latestVersion"  $packageversion
-        $config.packages.'GrandBend'.PackageVersion = $packageversion
+        if ($env:minimal_template_postgreSQL_package_alreadyupdated -eq 'false' )
+        {
+            $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Minimal.Template.PostgreSQL.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
+            $folderParts = $packageFolder -split "\."
+            $newRevision =$folderParts[$folderParts.Count- 2]
+            $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
+            Write-Host "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL latestVersion"  $packageversion
+            $config.packages.'PostgreSqlMinimalTemplate'.PackageVersion = $packageversion
+        }
 
-        $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Populated.Template.PostgreSQL.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
-        $folderParts = $packageFolder -split "\."
-        $newRevision =$folderParts[$folderParts.Count- 2]
-        $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
-        Write-Host " EdFi.Suite3.Ods.Populated.Template.PostgreSQL latestVersion"  $packageversion
-        $config.packages.'PostgreSqlPopulatedTemplate'.PackageVersion = $packageversion
+        if ($env:populated_template_package_alreadyupdated -eq 'false' )
+        {
+            $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Populated.Template.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
+            $folderParts = $packageFolder -split "\."
+            $newRevision =$folderParts[$folderParts.Count- 2]
+            $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
+            Write-Host " EdFi.Suite3.Ods.Populated.Template latestVersion"  $packageversion
+            $config.packages.'GrandBend'.PackageVersion = $packageversion
+        }
 
+        if ($env:populated_template_postgreSQL_package_alreadyupdated -eq 'false' )
+        {
+            $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Populated.Template.PostgreSQL.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
+            $folderParts = $packageFolder -split "\."
+            $newRevision =$folderParts[$folderParts.Count- 2]
+            $packageversion = "${{ env.INFORMATIONAL_VERSION }}.$newRevision" 
+            Write-Host " EdFi.Suite3.Ods.Populated.Template.PostgreSQL latestVersion"  $packageversion
+            $config.packages.'PostgreSqlPopulatedTemplate'.PackageVersion = $packageversion
+        }
         $config | ConvertTo-Json | Format-Json | Out-File -FilePath $filePath -Encoding UTF8
 
     - name: Commit and push updated EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL new package version
-      if: inputs.rebuildLevel == 'DatabaseTemplates'
+      if: ${{ ( env.minimal_template_package_alreadyupdated == 'false' || env.minimal_template_postgreSQL_package_alreadyupdated == 'false' || env.populated_template_package_alreadyupdated == 'false' || env.populated_template_postgreSQL_package_alreadyupdated == 'false') && ( inputs.rebuildLevel == 'DatabaseTemplates') }}
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
         git add ./configuration.packages.json
-        git commit -m "Updating for new EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL  package version"
+        git commit -m "Updating for new EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL package version"
         git push -u origin ${{ env.current_branch }}
 
     - name: Dispatch EdFi.Ods.Populated.Template.TPDM  workflow
@@ -624,8 +877,7 @@ jobs:
         run_id: ${{ steps.return_dispatch_populated_template_TPDM_postgresql.outputs.run_id }}
         check_artifacts: true
 
-
-    - name: update configuration.packages.json with all EdFi.Ods.Minimal.Template.TPDM , EdFi.Ods.Minimal.Template.TPDM.PostgreSQL ,EdFi.Ods.Populated.Template.TPDM ,EdFi.Ods.Populated.Template.TPDM.PostgreSQL new package version
+    - name: Update configuration.packages.json with all EdFi.Ods.Minimal.Template.TPDM , EdFi.Ods.Minimal.Template.TPDM.PostgreSQL ,EdFi.Ods.Populated.Template.TPDM ,EdFi.Ods.Populated.Template.TPDM.PostgreSQL new package version
       if: inputs.rebuildLevel == 'DatabaseTemplates'
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
@@ -663,6 +915,7 @@ jobs:
         $config.packages.'TPDMCorePostgreSqlPopulatedTemplate'.PackageVersion = $packageversion
 
         $config | ConvertTo-Json | Format-Json | Out-File -FilePath $filePath -Encoding UTF8
+
     - name: Commit and push updated EdFi.Ods.Minimal.Template.TPDM , EdFi.Ods.Minimal.Template.TPDM.PostgreSQL ,EdFi.Ods.Populated.Template.TPDM ,EdFi.Ods.Populated.Template.TPDM.PostgreSQL new package version
       if: inputs.rebuildLevel == 'DatabaseTemplates'
       working-directory: ./Ed-Fi-ODS-Implementation/
@@ -670,6 +923,7 @@ jobs:
         git add ./configuration.packages.json
         git commit -m "Updating for new EdFi.Ods.Minimal.Template.TPDM , EdFi.Ods.Minimal.Template.TPDM.PostgreSQL ,EdFi.Ods.Populated.Template.TPDM ,EdFi.Ods.Populated.Template.TPDM.PostgreSQL  package version"
         git push -u origin ${{ env.current_branch }}
+
     - name: Upload NugetPackages created using Rebuild Database Templates worfklow
       if: success() 
       uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Extract StandardVersion
       id: extract_version
-      run: echo "standard_version=4.0.0" >> $GITHUB_ENV
+      run: echo "standard_version=${{ fromJson(needs.FindStandardAndExtensionVersions.outputs.StandardVersions)[0] }}" >> $GITHUB_ENV
     - name: Checkout Ed-Fi-ODS-Implementation
       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
       with:

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -465,15 +465,15 @@ jobs:
         $filePath = "./configuration.packages.json"
         $config = Get-Content $filePath | ConvertFrom-Json
 
-        Write-Host "IsSameCommitinAllthreeRepository is $env:IsSameCommitinAllthreeRepository"
-        Write-Host "inputs_rebuildLevel is $env:inputs_rebuildLevel"
-        Write-Host "Homograph_package_alreadyupdated is $env:Homograph_package_alreadyupdated"
-        Write-Host "Sample_package_alreadyupdated is $env:Sample_package_alreadyupdated"                              
-        Write-Host "TPDM_package_alreadyupdated is $env:TPDM_package_alreadyupdated"
+        Write-Host "IsSameCommitinAllthreeRepository: ${{ env.IsSameCommitinAllthreeRepository }}"
+        Write-Host "inputs_rebuildLevel: ${{ github.event.inputs.inputs_rebuildLevel }}"
+        Write-Host "Homograph_package_alreadyupdated: ${{ env.Homograph_package_alreadyupdated }}"
+        Write-Host "Sample_package_alreadyupdated: ${{ env.Sample_package_alreadyupdated }}"
+        Write-Host "TPDM_package_alreadyupdated: ${{ env.TPDM_package_alreadyupdated }}"
 
-        $isCommitNotChanged = $env:IsSameCommitinAllthreeRepository -eq 'false'
-        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Homograph_package_alreadyupdated -eq 'false'
-        $isRebuildLevelValid = $env:inputs_rebuildLevel -in @('DotNetPackages', 'DatabaseTemplates')
+        $isCommitNotChanged = ${{ env.IsSameCommitinAllthreeRepository }} -eq 'false'
+        $isCommitChangedAndNotUpdated = ${{ env.IsSameCommitinAllthreeRepository }} -eq 'true' -and ${{ env.Homograph_package_alreadyupdated }} -eq 'false'
+        $isRebuildLevelValid = ${{ github.event.inputs.inputs_rebuildLevel }} -in @('DotNetPackages', 'DatabaseTemplates')
 
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
            {
@@ -485,7 +485,7 @@ jobs:
             $config.packages.'homograph'.PackageVersion = $packageversion
         }
 
-        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Sample_package_alreadyupdated -eq 'false'
+        $isCommitChangedAndNotUpdated = ${{ env.IsSameCommitinAllthreeRepository }} -eq 'true' -and ${{ env.Sample_package_alreadyupdated }} -eq 'false'
 
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
         {
@@ -497,7 +497,7 @@ jobs:
             $config.packages.'sample'.PackageVersion = $packageversion
         }
 
-        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:TPDM_package_alreadyupdated -eq 'false'
+        $isCommitChangedAndNotUpdated = ${{ env.IsSameCommitinAllthreeRepository }} -eq 'true' -and ${{ env.TPDM_package_alreadyupdated }} -eq 'false'
 
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
         {

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -151,7 +151,6 @@ jobs:
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-        Write-Host "IsSameCommitinAllthreeRepository is ${{ env.IsSameCommitinAllthreeRepository }}"
 
         $oneeightyDaysAgo = (Get-Date).AddDays(-180).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
         Write-Host "oneeightyDaysAgo Date and Time in ISO 8601 format: $oneeightyDaysAgo"
@@ -164,7 +163,6 @@ jobs:
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
-        Write-Host "IsSameCommitinAllthreeRepository is ${{ env.IsSameCommitinAllthreeRepository }}"
 
         $oneeightyDaysAgo = (Get-Date).AddDays(-180).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
         Write-Host "oneeightyDaysAgo Date and Time in ISO 8601 format: $oneeightyDaysAgo"
@@ -286,13 +284,22 @@ jobs:
         $config | ConvertTo-Json | Format-Json | Out-File -FilePath $filePath -Encoding UTF8
 
     - name: Commit and push updated EdFi.Ods.CodeGen package reference
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'false' || (env.IsSameCommitinAllthreeRepository == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}    
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-        git add ./configuration.packages.json
-        git commit -m "Updating for new CodeGen version"
-        git push -u origin ${{ env.current_branch }}
+          # Define the file path
+          $filePath = "./configuration.packages.json"
 
+          # Check if there are any changes in the file
+          $changesDetected = git diff --quiet $filePath; $LASTEXITCODE -eq 1
+
+          if ($changesDetected) {
+              Write-Host "Changes detected in configuration.packages.json. Committing and pushing."
+              git add $filePath
+              git commit -m "Updating for new CodeGen version"
+              git push -u origin $env:current_branch
+          } else {
+              Write-Host "No changes detected in configuration.packages.json. Skipping commit."
+          }
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Extensions.Homograph.yml
       working-directory: ./Ed-Fi-ODS-Implementation/
       if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
@@ -487,17 +494,19 @@ jobs:
     - name: Commit and push updated Extensions- TPDM, Sample, Homograph package references
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
-          # Check if there are any changes in the configuration.packages.json file
-          git diff --quiet ./configuration.packages.json
+          # Define the file path
+          $filePath = "./configuration.packages.json"
 
-          # $? holds the exit code of the last executed command
-          if (-not $?) {
-            Write-Host "No changes detected in configuration.packages.json. Skipping commit."
+          # Check if there are any changes in the file
+          $changesDetected = git diff --quiet $filePath; $LASTEXITCODE -eq 1
+
+          if ($changesDetected) {
+              Write-Host "Changes detected in configuration.packages.json. Committing and pushing."
+              git add $filePath
+              git commit -m "Updating for new Extensions- TPDM, Sample, Homograph package version"
+              git push -u origin $env:current_branch
           } else {
-            Write-Host "Changes detected in configuration.packages.json. Committing and pushing."
-            git add ./configuration.packages.json
-            git commit -m "Updating for new Extensions- TPDM, Sample, Homograph package version"
-            git push -u origin ${{ env.current_branch }}
+              Write-Host "No changes detected in configuration.packages.json. Skipping commit."
           }
 
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Populated.Template.yml
@@ -756,19 +765,20 @@ jobs:
     - name: Commit and push updated EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL new package version
       working-directory: ./Ed-Fi-ODS-Implementation/
       run: |
+          # Define the file path
+          $filePath = "./configuration.packages.json"
 
-          # Check if there are any changes in the configuration.packages.json file
-          git diff --quiet ./configuration.packages.json
+          # Check if there are any changes in the file
+          $changesDetected = git diff --quiet $filePath; $LASTEXITCODE -eq 1
 
-          # $? holds the exit code of the last executed command
-          if (-not $?) {
-            Write-Host "No changes detected in configuration.packages.json. Skipping commit."
+          if ($changesDetected) {
+              Write-Host "Changes detected in configuration.packages.json. Committing and pushing."
+              git add $filePath
+              git commit -m "Updating for new EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL package version"
+              git push -u origin $env:current_branch
           } else {
-            Write-Host "Changes detected in configuration.packages.json. Committing and pushing."
-            git add ./configuration.packages.json
-            git commit -m "Updating for new EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL package version"
-            git push -u origin ${{ env.current_branch }}
-          }        
+              Write-Host "No changes detected in configuration.packages.json. Skipping commit."
+          }
 
     - name: Dispatch EdFi.Ods.Populated.Template.TPDM  workflow
       if: inputs.rebuildLevel == 'DatabaseTemplates'

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -471,8 +471,11 @@ jobs:
         Write-Host "Sample_package_alreadyupdated is $env:Sample_package_alreadyupdated"                              
         Write-Host "TPDM_package_alreadyupdated is $env:TPDM_package_alreadyupdated"
 
-        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Homograph_package_alreadyupdated -eq 'false'))
-           -and ($env:inputs_rebuildLevel -in @('DotNetPackages', 'DatabaseTemplates')))
+        $isCommitNotChanged = $env:IsSameCommitinAllthreeRepository -eq 'false'
+        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Homograph_package_alreadyupdated -eq 'false'
+        $isRebuildLevelValid = $env:inputs_rebuildLevel -in @('DotNetPackages', 'DatabaseTemplates')
+
+        if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
            {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Homograph.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
@@ -482,8 +485,9 @@ jobs:
             $config.packages.'homograph'.PackageVersion = $packageversion
         }
 
-        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Sample_package_alreadyupdated -eq 'false'))
-           -and ($env:inputs_rebuildLevel -in @('DotNetPackages', 'DatabaseTemplates')))
+        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Sample_package_alreadyupdated -eq 'false'
+
+        if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Sample.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
@@ -493,8 +497,9 @@ jobs:
             $config.packages.'sample'.PackageVersion = $packageversion
         }
 
-        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:TPDM_package_alreadyupdated -eq 'false'))
-           -and ($env:inputs_rebuildLevel -in @('DotNetPackages', 'DatabaseTemplates')))
+        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:TPDM_package_alreadyupdated -eq 'false'
+
+        if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.TPDM.Core.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -495,7 +495,7 @@ jobs:
         Write-Host "isRebuildLevelValid: $isRebuildLevelValid"
 
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid)
-           {
+        {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Homograph.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
             $newRevision =$folderParts[$folderParts.Count- 2]
@@ -761,7 +761,35 @@ jobs:
         $filePath = "./configuration.packages.json"
         $config = Get-Content $filePath | ConvertFrom-Json
 
-        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')) -or (($env:IsSameCommitinAllthreeRepository -eq 'true') -and ($env:minimal_template_package_alreadyupdated -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates'))) 
+
+        Write-Host "IsSameCommitinAllthreeRepository: $env:IsSameCommitinAllthreeRepository"
+        Write-Host "inputs.rebuildLevel: ${{ github.event.inputs.rebuildLevel }}"
+
+        Write-Host "populated_template_successful_runexist: $env:populated_template_successful_runexist"
+        Write-Host "populated_template_package_alreadyupdated: $env:populated_template_package_alreadyupdated"
+
+        Write-Host "populated_template_postgreSQL_successful_runexist: $env:populated_template_postgreSQL_successful_runexist"
+        Write-Host "populated_template_postgreSQL_package_alreadyupdated: $env:populated_template_postgreSQL_package_alreadyupdated"
+
+        Write-Host "minimal_template_successful_runexist: $env:minimal_template_successful_runexist"
+        Write-Host "minimal_template_package_alreadyupdated: $env:minimal_template_package_alreadyupdated"
+
+        Write-Host "minimal_template_postgreSQL_successful_runexist: $env:minimal_template_postgreSQL_successful_runexist"
+        Write-Host "minimal_template_postgreSQL_package_alreadyupdated: $env:minimal_template_postgreSQL_package_alreadyupdated"  
+
+
+
+        # Evaluate conditions based on environment variables
+        $isCommitNotChanged = $env:IsSameCommitinAllthreeRepository -eq 'false'
+        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:minimal_template_package_alreadyupdated -eq 'false'
+        $rebuildLevel = '${{ github.event.inputs.rebuildLevel }}'
+        $isRebuildLevelValid = $rebuildLevel -in @('DatabaseTemplates')
+
+        Write-Host "isCommitNotChanged: $isCommitNotChanged"
+        Write-Host "isCommitChangedAndNotUpdated: $isCommitChangedAndNotUpdated"
+        Write-Host "isRebuildLevelValid: $isRebuildLevelValid"
+
+        if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid)
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Minimal.Template.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
@@ -771,7 +799,9 @@ jobs:
             $config.packages.'EdFiMinimalTemplate'.PackageVersion = $packageversion
         }
 
-        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')) -or (($env:IsSameCommitinAllthreeRepository -eq 'true') -and ($env:populated_template_package_alreadyupdated -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')))
+        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:minimal_template_postgreSQL_package_alreadyupdated -eq 'false'
+
+        if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid)
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Minimal.Template.PostgreSQL.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
@@ -781,7 +811,9 @@ jobs:
             $config.packages.'PostgreSqlMinimalTemplate'.PackageVersion = $packageversion
         }
 
-        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')) -or (($env:IsSameCommitinAllthreeRepository -eq 'true') -and ($env:populated_template_package_alreadyupdated -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')))
+        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:populated_template_package_alreadyupdated -eq 'false'
+
+        if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid)
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Populated.Template.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
@@ -791,7 +823,9 @@ jobs:
             $config.packages.'GrandBend'.PackageVersion = $packageversion
         }
 
-        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')) -or (($env:IsSameCommitinAllthreeRepository -eq 'true') -and ($env:populated_template_postgreSQL_package_alreadyupdated -eq 'false') -and ($inputs:rebuildLevel -eq 'DatabaseTemplates')))
+        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:populated_template_postgreSQL_package_alreadyupdated -eq 'false'
+
+        if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid)
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Populated.Template.PostgreSQL.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -111,7 +111,7 @@ jobs:
         $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/branches/${{ env.current_branch }}"
         .\build.githubactions.ps1  TestBranchExists -RepoName "Ed-Fi-Extensions" -BranchName "${{ env.current_branch }}" -Url $url
 
-    - name: Check any failed previous Workflow Run exist in current branch
+    - name: Check for any failed previous workflow runs in the current branch
       working-directory: ./Ed-Fi-ODS-Implementation/ 
       shell: pwsh
       run: |
@@ -135,7 +135,7 @@ jobs:
         if_no_artifact_found: ignore
       continue-on-error: true
 
-    - name: Read each repo last commit for repo Ed-Fi-ODS-Implementation and stored it in repositories.json 
+    - name: Read the last commit for Ed-Fi-ODS-Implementation and store it in repositories.json 
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
@@ -145,9 +145,9 @@ jobs:
         $branchName = "${{ env.current_branch }}"
         $sinceDate = $oneeightyDaysAgo 
         $implementationUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
-        .\build.githubactions.ps1 'AddOrUpdateRepositoriesJson' -Url $implementationUrl -RepoName 'Ed-Fi-ODS-Implementation'
+        .\build.githubactions.ps1 'CreateOrUpdateRepositoriesJson' -Url $implementationUrl -RepoName 'Ed-Fi-ODS-Implementation'
 
-    - name: Read each repo last commit for repo Ed-Fi-ODS and stored it in repositories.json 
+    - name: Read the last commit for Ed-Fi-ODS and store it in repositories.json 
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
@@ -157,9 +157,9 @@ jobs:
         $branchName = "${{ env.current_branch }}"
         $sinceDate = $oneeightyDaysAgo 
         $odsUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
-        .\build.githubactions.ps1  'AddOrUpdateRepositoriesJson' -Url $odsUrl -RepoName 'Ed-Fi-ODS'
+        .\build.githubactions.ps1  'CreateOrUpdateRepositoriesJson' -Url $odsUrl -RepoName 'Ed-Fi-ODS'
 
-    - name: Read each repo last commit for repo Ed-Fi-Extensions and stored it in repositories.json 
+    - name: Read the last commit for Ed-Fi-Extensions and store it in repositories.json 
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
@@ -169,7 +169,7 @@ jobs:
         $branchName = "${{ env.current_branch }}"
         $sinceDate = $oneeightyDaysAgo        
         $extensionsUrl = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/commits?sha=$branchName&since=$sinceDate&page=1&per_page=200"
-        .\build.githubactions.ps1  'AddOrUpdateRepositoriesJson' -Url $extensionsUrl -RepoName 'Ed-Fi-Extensions'
+        .\build.githubactions.ps1  'CreateOrUpdateRepositoriesJson' -Url $extensionsUrl -RepoName 'Ed-Fi-Extensions'
 
     - name: Check for IscommitChanged in repositories.json
       working-directory: ./Ed-Fi-ODS-Implementation/
@@ -185,12 +185,12 @@ jobs:
 
         if ($isCommitChanged) {
           # Set environment variable if any repository has IscommitChanged set to true
-          echo "IsSameCommitinAllthreeRepository=false" >> $Env:GITHUB_ENV
-          Write-Host "IsSameCommitinAllthreeRepository is false."
+          echo "NoNewCommitsInAllThreeRepositories=false" >> $Env:GITHUB_ENV
+          Write-Host "NoNewCommitsInAllThreeRepositories is false."
         } else {
           # Optionally, you can set it to false if no repository has IscommitChanged set to true
-          echo "IsSameCommitinAllthreeRepository=true" >> $Env:GITHUB_ENV
-           Write-Host "IsSameCommitinAllthreeRepository is true."
+          echo "NoNewCommitsInAllThreeRepositories=true" >> $Env:GITHUB_ENV
+           Write-Host "NoNewCommitsInAllThreeRepositories is true."
         }
         
         echo "Homograph_package_alreadyupdated=false" >> $Env:GITHUB_ENV
@@ -215,7 +215,7 @@ jobs:
  
     - name: Check if any successful workflow run in Pkg EdFi.Ods.CodeGen.yml
       working-directory: ./Ed-Fi-ODS-Implementation/     
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'true' }}
       shell: pwsh
       run: |
         $workflow_file_name = "Pkg EdFi.Ods.CodeGen.yml"
@@ -230,7 +230,7 @@ jobs:
         .\build.githubactions.ps1  'ComparePackageVersions' -PackageName 'EdFi.Ods.CodeGen' -StatusEnvName 'EdFi.Ods.CodeGen_package_alreadyupdated'
 
     - name: Dispatch EdFi.Ods.CodeGen workflow
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'false' || (env.IsSameCommitinAllthreeRepository == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'false' || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_codegen
       with:
@@ -242,7 +242,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Await to complete the execution for EdFi.Ods.CodeGen RunID ${{ steps.return_dispatch_codegen.outputs.run_id }}
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'false' || (env.IsSameCommitinAllthreeRepository == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'false' || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -253,7 +253,7 @@ jobs:
         poll_interval_ms: 5000
         
     - name: Download Codegen artifact using Run Id ${{ steps.return_dispatch_codegen.outputs.run_id }}
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'false' || (env.IsSameCommitinAllthreeRepository == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'false' || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.CodeGen.yml
@@ -281,7 +281,7 @@ jobs:
         git config user.email "${{ steps.import-gpg.outputs.email }}"
 
     - name: Update configuration.packages.json with EdFi.Ods.CodeGen new package version
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'false' || (env.IsSameCommitinAllthreeRepository == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}  
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'false' || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.EdFi.Ods.CodeGen_package_alreadyupdated == 'false') }}  
       working-directory: ./Ed-Fi-ODS-Implementation/
       shell: pwsh
       run: |
@@ -318,7 +318,7 @@ jobs:
           exit 0
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Extensions.Homograph.yml
       working-directory: ./Ed-Fi-ODS-Implementation/
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'true' }}
       shell: pwsh
       run: |
 
@@ -335,7 +335,7 @@ jobs:
 
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Extensions.Sample.yml
       working-directory: ./Ed-Fi-ODS-Implementation/
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'true' }}
       shell: pwsh
       run: |
         $workflow_file_name = "Pkg EdFi.Ods.Extensions.Sample.yml"
@@ -351,14 +351,14 @@ jobs:
 
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Extensions.TPDM.yml
       working-directory: ./Ed-Fi-ODS-Implementation/
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'true' }}
       shell: pwsh
       run: |
         $workflow_file_name = "Pkg EdFi.Ods.Extensions.TPDM.yml"
         $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-Extensions/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
         .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'TPDM_successful_runexist'
   
-    - name: Compare already configuration.packages.json updated with EdFi.Ods.Extensions.TPDM package Version
+    - name: Check if configuration.packages.json has an updated EdFi.Ods.Extensions.TPDM package Version
       working-directory: ./Ed-Fi-ODS-Implementation/
       if: ${{ env.TPDM_successful_runexist == 'true' }}
       shell: pwsh
@@ -366,7 +366,7 @@ jobs:
         .\build.githubactions.ps1  'ComparePackageVersions' -PackageName 'tpdm' -StatusEnvName 'TPDM_package_alreadyupdated'
 
     - name: Dispatch EdFi.Ods.Extensions.Homograph workflow
-      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Homograph_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}
+      if: ${{ ( env.NoNewCommitsInAllThreeRepositories == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.NoNewCommitsInAllThreeRepositories == 'true' && env.Homograph_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_homograph
       with:
@@ -378,7 +378,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Dispatch  EdFi.Ods.Extensions.Sample workflow
-      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Sample_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}
+      if: ${{ ( env.NoNewCommitsInAllThreeRepositories == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.NoNewCommitsInAllThreeRepositories == 'true' && env.Sample_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_sample
       with:
@@ -390,7 +390,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Dispatch  EdFi.Ods.Extensions.TPDM worflow
-      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.TPDM_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}
+      if: ${{ ( env.NoNewCommitsInAllThreeRepositories == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.NoNewCommitsInAllThreeRepositories == 'true' && env.TPDM_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_TPDM
       with:
@@ -402,7 +402,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Await to complete the execution for EdFi.Ods.Extensions.Homograph RunID ${{ steps.return_dispatch_homograph.outputs.run_id }}
-      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Homograph_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
+      if: ${{ ( env.NoNewCommitsInAllThreeRepositories == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.NoNewCommitsInAllThreeRepositories == 'true' && env.Homograph_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -413,7 +413,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Await to complete the execution for EdFi.Ods.Extensions.Sample RunID ${{ steps.return_dispatch_sample.outputs.run_id }}
-      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Sample_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
+      if: ${{ ( env.NoNewCommitsInAllThreeRepositories == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.NoNewCommitsInAllThreeRepositories == 'true' && env.Sample_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -424,7 +424,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Await to complete the execution for EdFi.Ods.Extensions.TPDM RunID ${{ steps.return_dispatch_TPDM.outputs.run_id }}
-      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.TPDM_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
+      if: ${{ ( env.NoNewCommitsInAllThreeRepositories == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.NoNewCommitsInAllThreeRepositories == 'true' && env.TPDM_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -435,7 +435,7 @@ jobs:
         poll_interval_ms: 5000
        
     - name: Download EdFi.Ods.Extensions.Homograph artifact using Run Id ${{ steps.return_dispatch_homograph.outputs.run_id }}
-      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Homograph_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}            
+      if: ${{ ( env.NoNewCommitsInAllThreeRepositories == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.NoNewCommitsInAllThreeRepositories == 'true' && env.Homograph_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}            
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Extensions.Homograph.yml
@@ -447,7 +447,7 @@ jobs:
         check_artifacts: true
 
     - name: Download EdFi.Ods.Extensions.Sample artifact using Run Id ${{ steps.return_dispatch_sample.outputs.run_id }}
-      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.Sample_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}            
+      if: ${{ ( env.NoNewCommitsInAllThreeRepositories == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.NoNewCommitsInAllThreeRepositories == 'true' && env.Sample_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}            
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Extensions.Sample.yml
@@ -459,7 +459,7 @@ jobs:
         check_artifacts: true
 
     - name: Download EdFi.Ods.Extensions.TPDM artifact using Run Id ${{ steps.return_dispatch_TPDM.outputs.run_id }}
-      if: ${{ ( env.IsSameCommitinAllthreeRepository == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.IsSameCommitinAllthreeRepository == 'true' && env.TPDM_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
+      if: ${{ ( env.NoNewCommitsInAllThreeRepositories == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates')) || ((env.NoNewCommitsInAllThreeRepositories == 'true' && env.TPDM_package_alreadyupdated == 'false' && (inputs.rebuildLevel == 'DotNetPackages' || inputs.rebuildLevel == 'DatabaseTemplates'))) }}      
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Extensions.TPDM.yml
@@ -478,15 +478,15 @@ jobs:
         $filePath = "./configuration.packages.json"
         $config = Get-Content $filePath | ConvertFrom-Json
 
-        Write-Host "IsSameCommitinAllthreeRepository: $env:IsSameCommitinAllthreeRepository"
+        Write-Host "NoNewCommitsInAllThreeRepositories: $env:NoNewCommitsInAllThreeRepositories"
         Write-Host "inputs.rebuildLevel: ${{ github.event.inputs.rebuildLevel }}"
         Write-Host "Homograph_package_alreadyupdated: $env:Homograph_package_alreadyupdated"
         Write-Host "Sample_package_alreadyupdated: $env:Sample_package_alreadyupdated"
         Write-Host "TPDM_package_alreadyupdated: $env:TPDM_package_alreadyupdated"
 
         # Evaluate conditions based on environment variables
-        $isCommitNotChanged = $env:IsSameCommitinAllthreeRepository -eq 'false'
-        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Homograph_package_alreadyupdated -eq 'false'
+        $isCommitNotChanged = $env:NoNewCommitsInAllThreeRepositories -eq 'false'
+        $isCommitChangedAndNotUpdated = $env:NoNewCommitsInAllThreeRepositories -eq 'true' -and $env:Homograph_package_alreadyupdated -eq 'false'
         $rebuildLevel = '${{ github.event.inputs.rebuildLevel }}'
         $isRebuildLevelValid = $rebuildLevel -in @('DotNetPackages', 'DatabaseTemplates')
 
@@ -504,7 +504,7 @@ jobs:
             $config.packages.'homograph'.PackageVersion = $packageversion
         }
 
-        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Sample_package_alreadyupdated -eq 'false'
+        $isCommitChangedAndNotUpdated = $env:NoNewCommitsInAllThreeRepositories -eq 'true' -and $env:Sample_package_alreadyupdated -eq 'false'
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
         {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Sample.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
@@ -515,7 +515,7 @@ jobs:
             $config.packages.'sample'.PackageVersion = $packageversion
         }
 
-        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:TPDM_package_alreadyupdated -eq 'false'
+        $isCommitChangedAndNotUpdated = $env:NoNewCommitsInAllThreeRepositories -eq 'true' -and $env:TPDM_package_alreadyupdated -eq 'false'
 
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid )
         {
@@ -551,14 +551,14 @@ jobs:
           exit 0
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Populated.Template.yml
       working-directory: ./Ed-Fi-ODS-Implementation/
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'true' }}
       shell: pwsh
       run: |
         $workflow_file_name = "Pkg EdFi.Ods.Populated.Template.yml"
         $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
         .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'populated_template_successful_runexist'
   
-    - name: Compare already configuration.packages.json updated with EdFi.Ods.Populated.Template package Version
+    - name: Check if configuration.packages.json has an updated EdFi.Ods.Populated.Template package Version
       working-directory: ./Ed-Fi-ODS-Implementation/
       if: ${{ env.populated_template_successful_runexist == 'true' }}
       shell: pwsh
@@ -567,14 +567,14 @@ jobs:
 
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
       working-directory: ./Ed-Fi-ODS-Implementation/
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'true' }}
       shell: pwsh
       run: |
         $workflow_file_name = "Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml"
         $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
         .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'populated_template_postgreSQL_successful_runexist'
   
-    - name: Compare already configuration.packages.json updated with EdFi.Ods.Populated.Template.PostgreSQL package Version
+    - name: Check if configuration.packages.json has an updated EdFi.Ods.Populated.Template.PostgreSQL package Version
       working-directory: ./Ed-Fi-ODS-Implementation/
       if: ${{ env.populated_template_postgreSQL_successful_runexist == 'true' }}
       shell: pwsh
@@ -583,14 +583,14 @@ jobs:
 
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Minimal.Template.yml
       working-directory: ./Ed-Fi-ODS-Implementation/
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'true' }}
       shell: pwsh
       run: |
         $workflow_file_name = "Pkg EdFi.Ods.Minimal.Template.yml"
         $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
         .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'minimal_template_successful_runexist'
   
-    - name: Compare already configuration.packages.json updated with EdFi.Ods.Minimal.Template package Version
+    - name: Check if configuration.packages.json has an updated EdFi.Ods.Minimal.Template package Version
       working-directory: ./Ed-Fi-ODS-Implementation/
       if: ${{ env.minimal_template_successful_runexist == 'true' }}
       shell: pwsh
@@ -599,14 +599,14 @@ jobs:
 
     - name: Check if any successful workflow run in Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
       working-directory: ./Ed-Fi-ODS-Implementation/
-      if: ${{ env.IsSameCommitinAllthreeRepository == 'true' }}
+      if: ${{ env.NoNewCommitsInAllThreeRepositories == 'true' }}
       shell: pwsh
       run: |
         $workflow_file_name = "Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml"
         $url = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/workflows/$workflow_file_name/runs?branch=${{ env.current_branch }}"
         .\build.githubactions.ps1  'WorkflowCheck' -Url $url -ExpectedStatus 'completed' -ExpectedConclusions  @('success') -StatusEnvName 'minimal_template_postgreSQL_successful_runexist'
   
-    - name: Compare already configuration.packages.json updated with EdFi.Ods.Minimal.Template.PostgreSQL package Version
+    - name: Check if configuration.packages.json has an updated EdFi.Ods.Minimal.Template.PostgreSQL package Version
       working-directory: ./Ed-Fi-ODS-Implementation/
       if: ${{ env.minimal_template_postgreSQL_successful_runexist == 'true' }}
       shell: pwsh
@@ -614,7 +614,7 @@ jobs:
         .\build.githubactions.ps1  'ComparePackageVersions' -PackageName 'PostgreSqlMinimalTemplate' -StatusEnvName 'minimal_template_postgreSQL_package_alreadyupdated'
 
     - name: Dispatch EdFi.Ods.Populated.Template workflow
-      if: ${{ ((env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ ((env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.populated_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_populated_template
       with:
@@ -626,7 +626,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Dispatch EdFi.Ods.Populated.Template.PostgreSQL workflow
-      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ (( env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.populated_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_populated_template_postgresql
       with:
@@ -638,7 +638,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Dispatch EdFi.Ods.Minimal.Template  workflow
-      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ (( env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.minimal_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_minimal_template
       with:
@@ -650,7 +650,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Dispatch EdFi.Ods.Minimal.Template.PostgreSQL  workflow
-      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ (( env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.minimal_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/return-dispatch@9a2340d279253061c98206106038aab6ef0be02e #v1.14.0
       id: return_dispatch_minimal_template_postgresql
       with:
@@ -662,7 +662,7 @@ jobs:
         workflow_timeout_seconds: 4800
 
     - name: Await to complete the execution for EdFi.Ods.Minimal.Template.PostgreSQL RunID ${{ steps.return_dispatch_minimal_template_postgresql.outputs.run_id }}
-      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ (( env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.minimal_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -673,7 +673,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Await to complete the execution for EdFi.Ods.Minimal.Template RunID ${{ steps.return_dispatch_minimal_template.outputs.run_id }}
-      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ (( env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.minimal_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -684,7 +684,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Await to complete the execution for EdFi.Ods.Populated.Template RunID ${{ steps.return_dispatch_populated_template.outputs.run_id }}
-      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ (( env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.populated_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -695,7 +695,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Await to complete the execution for EdFi.Ods.Populated.Template.PostgreSQL RunID ${{ steps.return_dispatch_populated_template_postgresql.outputs.run_id }}
-      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ (( env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.populated_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: Codex-/await-remote-run@d4a6dbf57245924ff4f23e0db929b8e3ef65486b #v1.12.2
       with:
         token: ${{ env.EDFI_ODS_TOKEN }}
@@ -706,7 +706,7 @@ jobs:
         poll_interval_ms: 5000
 
     - name: Download EdFi.Ods.Minimal.Template artifact using Run Id ${{ steps.return_dispatch_minimal_template.outputs.run_id }}
-      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ (( env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.minimal_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Minimal.Template.yml
@@ -718,7 +718,7 @@ jobs:
         check_artifacts: true
 
     - name: Download EdFi.Ods.Minimal.Template.PostgreSQL artifact using Run Id ${{ steps.return_dispatch_minimal_template_postgresql.outputs.run_id }}
-      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.minimal_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ (( env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.minimal_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Minimal.Template.PostgreSQL.yml
@@ -730,7 +730,7 @@ jobs:
         check_artifacts: true
 
     - name: Download EdFi.Ods.Populated.Template artifact using Run Id ${{ steps.return_dispatch_populated_template.outputs.run_id }}
-      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ (( env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.populated_template_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Populated.Template.yml
@@ -742,7 +742,7 @@ jobs:
         check_artifacts: true
 
     - name: Download EdFi.Ods.Populated.Template.PostgreSQL artifact using Run Id ${{ steps.return_dispatch_populated_template_postgresql.outputs.run_id }}
-      if: ${{ (( env.IsSameCommitinAllthreeRepository == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.IsSameCommitinAllthreeRepository == 'true' && env.populated_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
+      if: ${{ (( env.NoNewCommitsInAllThreeRepositories == 'false' && inputs.rebuildLevel == 'DatabaseTemplates') || (env.NoNewCommitsInAllThreeRepositories == 'true' && env.populated_template_postgreSQL_package_alreadyupdated == 'false' &&  inputs.rebuildLevel == 'DatabaseTemplates')) }}
       uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67  #v3.1.2
       with:
         workflow: Pkg EdFi.Ods.Populated.Template.PostgreSQL.yml
@@ -762,7 +762,7 @@ jobs:
         $config = Get-Content $filePath | ConvertFrom-Json
 
 
-        Write-Host "IsSameCommitinAllthreeRepository: $env:IsSameCommitinAllthreeRepository"
+        Write-Host "NoNewCommitsInAllThreeRepositories: $env:NoNewCommitsInAllThreeRepositories"
         Write-Host "inputs.rebuildLevel: ${{ github.event.inputs.rebuildLevel }}"
 
         Write-Host "populated_template_successful_runexist: $env:populated_template_successful_runexist"
@@ -780,8 +780,8 @@ jobs:
 
 
         # Evaluate conditions based on environment variables
-        $isCommitNotChanged = $env:IsSameCommitinAllthreeRepository -eq 'false'
-        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:minimal_template_package_alreadyupdated -eq 'false'
+        $isCommitNotChanged = $env:NoNewCommitsInAllThreeRepositories -eq 'false'
+        $isCommitChangedAndNotUpdated = $env:NoNewCommitsInAllThreeRepositories -eq 'true' -and $env:minimal_template_package_alreadyupdated -eq 'false'
         $rebuildLevel = '${{ github.event.inputs.rebuildLevel }}'
         $isRebuildLevelValid = $rebuildLevel -in @('DatabaseTemplates')
 
@@ -799,7 +799,7 @@ jobs:
             $config.packages.'EdFiMinimalTemplate'.PackageVersion = $packageversion
         }
 
-        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:minimal_template_postgreSQL_package_alreadyupdated -eq 'false'
+        $isCommitChangedAndNotUpdated = $env:NoNewCommitsInAllThreeRepositories -eq 'true' -and $env:minimal_template_postgreSQL_package_alreadyupdated -eq 'false'
 
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid)
         {
@@ -811,7 +811,7 @@ jobs:
             $config.packages.'PostgreSqlMinimalTemplate'.PackageVersion = $packageversion
         }
 
-        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:populated_template_package_alreadyupdated -eq 'false'
+        $isCommitChangedAndNotUpdated = $env:NoNewCommitsInAllThreeRepositories -eq 'true' -and $env:populated_template_package_alreadyupdated -eq 'false'
 
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid)
         {
@@ -823,7 +823,7 @@ jobs:
             $config.packages.'GrandBend'.PackageVersion = $packageversion
         }
 
-        $isCommitChangedAndNotUpdated = $env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:populated_template_postgreSQL_package_alreadyupdated -eq 'false'
+        $isCommitChangedAndNotUpdated = $env:NoNewCommitsInAllThreeRepositories -eq 'true' -and $env:populated_template_postgreSQL_package_alreadyupdated -eq 'false'
 
         if (($isCommitNotChanged -or $isCommitChangedAndNotUpdated) -and $isRebuildLevelValid)
         {

--- a/.github/workflows/Rebuild Database Templates.yml
+++ b/.github/workflows/Rebuild Database Templates.yml
@@ -465,7 +465,15 @@ jobs:
         $filePath = "./configuration.packages.json"
         $config = Get-Content $filePath | ConvertFrom-Json
 
-        if (($env:IsSameCommitinAllthreeRepository -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates')) -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Homograph_package_alreadyupdated -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates'))){
+        Write-Host "IsSameCommitinAllthreeRepository is $env:IsSameCommitinAllthreeRepository"
+        Write-Host "inputs_rebuildLevel is $env:inputs_rebuildLevel"
+        Write-Host "Homograph_package_alreadyupdated is $env:Homograph_package_alreadyupdated"
+        Write-Host "Sample_package_alreadyupdated is $env:Sample_package_alreadyupdated"                              
+        Write-Host "TPDM_package_alreadyupdated is $env:TPDM_package_alreadyupdated"
+
+        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Homograph_package_alreadyupdated -eq 'false'))
+           -and ($env:inputs_rebuildLevel -in @('DotNetPackages', 'DatabaseTemplates')))
+           {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Homograph.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
             $newRevision =$folderParts[$folderParts.Count- 2]
@@ -474,7 +482,9 @@ jobs:
             $config.packages.'homograph'.PackageVersion = $packageversion
         }
 
-        if (($env:IsSameCommitinAllthreeRepository -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates')) -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Sample_package_alreadyupdated -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates'))){
+        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:Sample_package_alreadyupdated -eq 'false'))
+           -and ($env:inputs_rebuildLevel -in @('DotNetPackages', 'DatabaseTemplates')))
+        {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.Sample.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
             $newRevision =$folderParts[$folderParts.Count- 2]
@@ -483,7 +493,9 @@ jobs:
             $config.packages.'sample'.PackageVersion = $packageversion
         }
 
-        if (($env:IsSameCommitinAllthreeRepository -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates')) -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:TPDM_package_alreadyupdated -eq 'false' -and ($env:inputs_rebuildLevel -eq 'DotNetPackages' -or $env:inputs_rebuildLevel -eq 'DatabaseTemplates'))){
+        if ((($env:IsSameCommitinAllthreeRepository -eq 'false') -or ($env:IsSameCommitinAllthreeRepository -eq 'true' -and $env:TPDM_package_alreadyupdated -eq 'false'))
+           -and ($env:inputs_rebuildLevel -in @('DotNetPackages', 'DatabaseTemplates')))
+        {
             $packageFolder = Get-Item -Path "${{ github.workspace }}/Ed-Fi-ODS-Implementation/NugetPackages/EdFi.Suite3.Ods.Extensions.TPDM.Core.*${{ env.INFORMATIONAL_VERSION }}.*" | Select-Object -Expand Name
             $folderParts = $packageFolder -split "\."
             $newRevision =$folderParts[$folderParts.Count- 2]

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -418,9 +418,6 @@ function AddOrUpdateRepositoriesJson {
         exit 1
     }
 
-    # # Define the user who triggered the workflow
-    # $triggeredBy = $Env:GITHUB_ACTOR
-
     # # Filter out the commits with the ignored messages
     $filteredCommits = $response | Where-Object { $ignoreMessages -notcontains $_.commit.message }
 
@@ -457,13 +454,16 @@ function AddOrUpdateRepositoriesJson {
                 Write-Host "Printing before updating new Commit ID"
                 Get-Content $filePath | Write-Host
                 Write-Host "New commit ID   is different with old Commit Id "
+                $repoEntry.repo_name = $RepoName                
                 $repoEntry.commit_message = $commitMessage
                 $repoEntry.commit_id = $commitId
                 Write-Host "Updated repository entry for $RepoName with new commit ID."
                 echo "$statusEnvName=false" >> $Env:GITHUB_ENV
+                Write-Host "$statusEnvName is false."
             } else {
                 Write-Host "The commit ID for $RepoName is already up to date."
                 echo "$statusEnvName=true" >> $Env:GITHUB_ENV
+                Write-Host "$statusEnvName is true."                
             }
         } else {
             # Add new entry if the repository entry does not exist
@@ -475,6 +475,7 @@ function AddOrUpdateRepositoriesJson {
             $jsonContent.repositories += $newRepoEntry
             Write-Host "Added new repository entry for $RepoName."
             echo "$statusEnvName=true" >> $Env:GITHUB_ENV
+            Write-Host "$statusEnvName is true."            
         }
 
         # Write updated content back to the file

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -391,21 +391,6 @@ function AddOrUpdateRepositoriesJson {
     # Fetch the last commit details
     $response = Invoke-RestMethod -Uri $url -Headers $headers
 
-    Write-Host "Printing response from API using URL $url without any fliter"
-
-    # Initialize a counter
-    $rowNumber = 1
-
-    foreach ($commit in $response) {
-        $commitMessage = $commit.commit.message
-        # $authorName = $commit.commit.author.name
-        # Write-Host "----------------------------"        
-        Write-Host "Commit Message: $commitMessage"
-        # Write-Host "Author Name: $authorName"
-        # Write-Host "Row Number: $rowNumber"
-        # Write-Host "----------------------------"
-        $rowNumber++
-    }
     #Define the messages to ignore
     $ignoreMessages = @(
         "Updating for new CodeGen version",
@@ -498,8 +483,8 @@ function AddOrUpdateRepositoriesJson {
             )
         }
         $initialContent | ConvertTo-Json -Depth 4 | Out-File -FilePath $FilePath -Encoding UTF8
-        echo "$statusEnvName=true" >> $Env:GITHUB_ENV
-        Write-Host "$statusEnvName is true."  
+        echo "$statusEnvName=false" >> $Env:GITHUB_ENV
+        Write-Host "$statusEnvName is false."  
     }
 
     # Print the repositories.json content for verification

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -7,7 +7,7 @@
 param(
     # Command to execute, defaults to "Build".
     [string]
-    [ValidateSet("DotnetClean", "Restore", "Build", "Test", "Pack", "Publish", "CheckoutBranch","StandardVersions", "InstallCredentialHandler")]
+    [ValidateSet("DotnetClean", "Restore", "Build", "Test", "Pack", "Publish", "CheckoutBranch","StandardVersions", "InstallCredentialHandler","WorkflowCheck","ComparePackageVersions","AddOrUpdateRepositoriesJson","TestBranchExists")]
     $Command = "Build",
 
     [switch] $SelfContained,
@@ -58,7 +58,19 @@ param(
     $RelativeRepoPath,
 
     [ValidateSet('4.0.0', '5.1.0')]
-    [string]  $StandardVersion
+    [string]  $StandardVersion,
+
+    [string]$Url,
+
+    [string]$ExpectedStatus = 'completed',
+
+    [string[]]$ExpectedConclusions = 'success',
+
+    [string]$StatusEnvName,
+
+    [string]$RepoName,
+
+    [string]$BranchName
 )
 
 $newRevision = ([int]$BuildCounter) + ([int]$BuildIncrementer)
@@ -288,6 +300,229 @@ function StandardVersions {
     return $standardVersions
 }
 
+function WorkflowCheck {
+    $headers = @{
+        Authorization = "Bearer $env:EDFI_ODS_TOKEN"
+        Accept = "application/vnd.github.v3+json"
+    }
+    
+    $response = Invoke-RestMethod -Uri $Url -Headers $headers
+    
+    if ( $response.workflow_runs.Count -gt 0) {
+        Write-Host "Found workflow runs for URL: $Url."
+    
+        $runTracker = @{}  # Create an empty hash table to track printed run_numbers
+    
+        $response.workflow_runs | Where-Object { $_.status -eq $ExpectedStatus -and $ExpectedConclusions -contains $_.conclusion } | 
+         Sort-Object -Property run_number -Descending | Select-Object -First 1| ForEach-Object {
+            if (-not $runTracker.ContainsKey($_.run_number)) {
+                Write-Host "Run ID: $($_.id)"
+                Write-Host "Run Name: $($_.name)"
+                Write-Host "Run Number: $($_.run_number)"
+                Write-Host "Event: $($_.event)"
+                Write-Host "Status: $($_.status)"
+                Write-Host "Conclusion: $($_.conclusion)"
+                Write-Host "Created At: $($_.created_at)"
+                Write-Host "Updated At: $($_.updated_at)"
+                Write-Host "URL: $($_.html_url)"
+    
+                # Mark this run_number as printed
+                $runTracker[$_.run_number] = $true
+                echo "$StatusEnvName=true" >> $Env:GITHUB_ENV
+                echo "rebuild_database_templates_lastrunId=$($_.id)" >> $Env:GITHUB_ENV
+            }
+        }
+    } else {
+        Write-Host "No matching workflow runs found for URL: $Url."
+        echo "$StatusEnvName=false" >> $Env:GITHUB_ENV
+    }
+}
+
+function ComparePackageVersions {
+    # API URLs for branch and main
+    $url_branch = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/contents/configuration.packages.json?ref=$Env:current_branch"
+    $url_main = "https://api.github.com/repos/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/contents/configuration.packages.json?ref=main"
+
+    $headers = @{
+        Authorization = "Bearer $env:EDFI_ODS_TOKEN"
+        Accept = "application/vnd.github.v3+json"
+    }
+
+    # Get the file content for the branch
+    $response_branch = Invoke-RestMethod -Uri $url_branch -Headers $headers
+    $content_branch = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($response_branch.content))
+    $json_branch = $content_branch | ConvertFrom-Json
+
+    # Get the file content for the main branch
+    $response_main = Invoke-RestMethod -Uri $url_main -Headers $headers
+    $content_main = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($response_main.content))
+    $json_main = $content_main | ConvertFrom-Json
+    # Extract the PackageVersion for the package name
+    $branch_version = $json_branch.packages.$PackageName.PackageVersion
+    $main_version = $json_main.packages.$PackageName.PackageVersion
+
+    # Convert versions to a comparable format 
+    $branch_version = [Version]$branch_version
+    $main_version = [Version]$main_version
+
+    # Compare the versions and print
+    if ($branch_version -gt $main_version) {
+        Write-Host "Package versions are different:"
+        Write-Host "Branch ($branch): $branch_version"
+        Write-Host "Main: $main_version"
+        echo "$StatusEnvName=true" >> $Env:GITHUB_ENV
+    } else {
+        Write-Host "Package versions are the same:"
+        Write-Host "Branch ($branch): $branch_version"
+        Write-Host "Main: $main_version"
+        echo "$StatusEnvName=false" >> $Env:GITHUB_ENV
+    }
+}
+
+function AddOrUpdateRepositoriesJson {
+
+    $FilePath = "repositories.json"
+
+    $headers = @{
+        Authorization = "Bearer $env:EDFI_ODS_TOKEN"
+        Accept = "application/vnd.github.v3+json"
+    }
+
+    # Fetch the last commit details
+    $response = Invoke-RestMethod -Uri $url -Headers $headers
+
+    Write-Host "Printing response from API using URL $url without any fliter"
+
+    # Initialize a counter
+    $rowNumber = 1
+
+    foreach ($commit in $response) {
+        $commitMessage = $commit.commit.message
+        $authorName = $commit.commit.author.name
+        Write-Host "----------------------------"        
+        Write-Host "Commit Message: $commitMessage"
+        Write-Host "Author Name: $authorName"
+        Write-Host "Row Number: $rowNumber"
+        Write-Host "----------------------------"
+        $rowNumber++
+    }
+    #Define the messages to ignore
+    $ignoreMessages = @(
+        "Updating for new CodeGen version",
+        "Updating for new Extensions- TPDM, Sample, Homograph package version",
+        "Updating for new EdFi.Ods.Minimal.Template , EdFi.Ods.Minimal.Template.PostgreSQL ,EdFi.Ods.Populated.Template ,EdFi.Ods.Populated.Template.PostgreSQL package version"
+    )
+
+    if ($null -eq $response -or $response.Length -eq 0) {
+        Write-Host "API response is null or empty. Stopping the build."
+        exit 1
+    }
+
+    # # Define the user who triggered the workflow
+    # $triggeredBy = $Env:GITHUB_ACTOR
+
+    # # Filter out the commits with the ignored messages
+    $filteredCommits = $response | Where-Object { $ignoreMessages -notcontains $_.commit.message }
+
+    if ($null -eq $filteredCommits) {
+        Write-Host "Stopping the build. filteredCommits returns null"
+        exit 1
+    }
+
+    if ($filteredCommits -and $filteredCommits.Count -gt 0) {
+        $latestCommit = $filteredCommits[0]
+        $commitMessage = $latestCommit.commit.message
+        $commitId = $latestCommit.sha
+    } else {
+        Write-Host "No valid commits found after filtering. Stopping the build."
+        exit 1
+    }
+
+    # Check if the file exists
+    if (Test-Path $FilePath) {
+        # Read the existing content
+        $jsonContent = Get-Content -Path $FilePath -Raw | ConvertFrom-Json
+
+        if ($null -eq $jsonContent.repositories) {
+            $jsonContent.repositories = @()
+        }
+
+        # Find the repository entry or create a new one
+        $repoEntry = $jsonContent.repositories | Where-Object { $_.repo_name -eq $RepoName }
+        
+        if ($repoEntry) {
+            # Check if the existing commit ID is different from the latest commit ID
+            if ($repoEntry.commit_id -ne $commitId) {
+                # Update the entry if the commit ID is different
+                Write-Host "Printing before updating new Commit ID"
+                Get-Content $filePath | Write-Host
+                Write-Host "New commit ID   is different with old Commit Id "
+                $repoEntry.commit_message = $commitMessage
+                $repoEntry.commit_id = $commitId
+                Write-Host "Updated repository entry for $RepoName with new commit ID."
+                echo "$statusEnvName=false" >> $Env:GITHUB_ENV
+            } else {
+                Write-Host "The commit ID for $RepoName is already up to date."
+                echo "$statusEnvName=true" >> $Env:GITHUB_ENV
+            }
+        } else {
+            # Add new entry if the repository entry does not exist
+            $newRepoEntry = @{
+                repo_name      = $RepoName
+                commit_message = $commitMessage
+                commit_id      = $commitId
+            }
+            $jsonContent.repositories += $newRepoEntry
+            Write-Host "Added new repository entry for $RepoName."
+            echo "$statusEnvName=true" >> $Env:GITHUB_ENV
+        }
+
+        # Write updated content back to the file
+        $jsonContent | ConvertTo-Json -Depth 4 | Out-File -FilePath $FilePath -Encoding UTF8
+    } else {
+        # Create a new file with the initial content
+        $initialContent = @{
+            repositories = @(
+                @{
+                    repo_name      = $RepoName
+                    commit_message = $CommitMessage
+                    commit_id      = $CommitId
+                }
+            )
+        }
+        $initialContent | ConvertTo-Json -Depth 4 | Out-File -FilePath $FilePath -Encoding UTF8
+        echo "$statusEnvName=true" >> $Env:GITHUB_ENV
+    }
+
+    # Print the repositories.json content for verification
+     Write-Host "Print the repositories.json content for verification"
+      Get-Content $filePath | Write-Host
+}
+
+function TestBranchExists {
+
+    $headers = @{
+        Authorization = "Bearer $env:EDFI_ODS_TOKEN"
+        Accept        = "application/vnd.github.v3+json"
+    }
+
+    try {
+        $response = Invoke-RestMethod -Uri $url -Headers $headers
+        if ($response.name -eq $BranchName) {
+            Write-Host "Branch '$BranchName' exists in repository '$RepoName'."
+            return
+        } else {
+            Write-Host "Branch '$BranchName' does not exist in repository '$RepoName'."
+            Write-Host "Stopping the build."
+            exit 1
+        }
+    } catch {
+        Write-Host "Branch '$BranchName' does not exist in repository '$RepoName'."
+        Write-Host "Stopping the build."
+        exit 1
+    }
+}
+
 function Invoke-StandardVersions {
     Invoke-Step { StandardVersions }
 }
@@ -326,6 +561,22 @@ function Invoke-InstallCredentialHandler {
     Invoke-Step { InstallCredentialHandler }
 }
 
+function Invoke-WorkflowCheck {
+    Invoke-Step { WorkflowCheck }
+}
+
+function Invoke-ComparePackageVersions {
+    Invoke-Step { ComparePackageVersions }
+}
+
+function Invoke-AddOrUpdateRepositoriesJson {
+    Invoke-Step { AddOrUpdateRepositoriesJson }
+}
+
+function Invoke-TestBranchExists {
+    Invoke-Step { TestBranchExists }
+}
+
 Invoke-Main {
     switch ($Command) {
         DotnetClean { Invoke-DotnetClean }
@@ -336,7 +587,12 @@ Invoke-Main {
         Publish { Invoke-Publish }
         CheckoutBranch { Invoke-CheckoutBranch }
         InstallCredentialHandler { Invoke-InstallCredentialHandler }
-        StandardVersions { Invoke-StandardVersions }        
+        StandardVersions { Invoke-StandardVersions }
+        WorkflowCheck { Invoke-WorkflowCheck }
+        ComparePackageVersions { Invoke-ComparePackageVersions }
+        AddOrUpdateRepositoriesJson { Invoke-AddOrUpdateRepositoriesJson } 
+        TestBranchExists { Invoke-TestBranchExists }               
+        
         default { throw "Command '$Command' is not recognized" }
     }
 }

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -420,6 +420,8 @@ function AddOrUpdateRepositoriesJson {
         exit 1
     }
 
+    $jsonContent = null
+
     # Check if the file exists
     if (Test-Path $FilePath) {
 
@@ -452,7 +454,8 @@ function AddOrUpdateRepositoriesJson {
                 Write-Host "IscommitChanged is true."
             } else {
                 Write-Host "The commit ID for $RepoName is already up to date."
-                Write-Host "IscommitChanged is false."               
+                Write-Host "IscommitChanged is false."  
+                $repoEntry.IscommitChanged = 'false'                      
             }
         } else {
             # Add new entry if the repository entry does not exist
@@ -466,13 +469,10 @@ function AddOrUpdateRepositoriesJson {
             Write-Host "Added new repository entry for $RepoName."
             Write-Host "IscommitChanged is true."         
         }
-
-        # Write updated content back to the file
-        $jsonContent | ConvertTo-Json -Depth 4 | Out-File -FilePath $FilePath -Encoding UTF8
     } else {
         # Create a new file with the initial content
         Write-Host "File not Exists $FilePath .new file is created"        
-        $initialContent = @{
+        $jsonContent = @{
             repositories = @(
                 @{
                     repo_name      = $RepoName
@@ -482,13 +482,15 @@ function AddOrUpdateRepositoriesJson {
                 }
             )
         }
-        $initialContent | ConvertTo-Json -Depth 4 | Out-File -FilePath $FilePath -Encoding UTF8
         Write-Host "IscommitChanged is true." 
     }
 
+    # Write updated content back to the file
+    $jsonContent | ConvertTo-Json -Depth 4 | Out-File -FilePath $FilePath -Encoding UTF8
+
     # Print the repositories.json content for verification
      Write-Host "Print the repositories.json content for verification"
-      Get-Content $filePath | Write-Host
+     Get-Content $filePath | Write-Host
 }
 
 function TestBranchExists {

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -420,7 +420,7 @@ function AddOrUpdateRepositoriesJson {
         exit 1
     }
 
-    $jsonContent = null
+    $jsonContent = $null
 
     # Check if the file exists
     if (Test-Path $FilePath) {

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -7,7 +7,7 @@
 param(
     # Command to execute, defaults to "Build".
     [string]
-    [ValidateSet("DotnetClean", "Restore", "Build", "Test", "Pack", "Publish", "CheckoutBranch","StandardVersions", "InstallCredentialHandler","WorkflowCheck","ComparePackageVersions","AddOrUpdateRepositoriesJson","TestBranchExists")]
+    [ValidateSet("DotnetClean", "Restore", "Build", "Test", "Pack", "Publish", "CheckoutBranch","StandardVersions", "InstallCredentialHandler","WorkflowCheck","ComparePackageVersions","CreateOrUpdateRepositoriesJson","TestBranchExists")]
     $Command = "Build",
 
     [switch] $SelfContained,
@@ -379,7 +379,7 @@ function ComparePackageVersions {
     }
 }
 
-function AddOrUpdateRepositoriesJson {
+function CreateOrUpdateRepositoriesJson {
 
     $FilePath = "repositories.json"
 
@@ -563,8 +563,8 @@ function Invoke-ComparePackageVersions {
     Invoke-Step { ComparePackageVersions }
 }
 
-function Invoke-AddOrUpdateRepositoriesJson {
-    Invoke-Step { AddOrUpdateRepositoriesJson }
+function Invoke-CreateOrUpdateRepositoriesJson {
+    Invoke-Step { CreateOrUpdateRepositoriesJson }
 }
 
 function Invoke-TestBranchExists {
@@ -584,7 +584,7 @@ Invoke-Main {
         StandardVersions { Invoke-StandardVersions }
         WorkflowCheck { Invoke-WorkflowCheck }
         ComparePackageVersions { Invoke-ComparePackageVersions }
-        AddOrUpdateRepositoriesJson { Invoke-AddOrUpdateRepositoriesJson } 
+        CreateOrUpdateRepositoriesJson { Invoke-CreateOrUpdateRepositoriesJson } 
         TestBranchExists { Invoke-TestBranchExists }               
         
         default { throw "Command '$Command' is not recognized" }

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -447,13 +447,12 @@ function AddOrUpdateRepositoriesJson {
                 $repoEntry.repo_name = $RepoName                
                 $repoEntry.commit_message = $commitMessage
                 $repoEntry.commit_id = $commitId
+                $repoEntry.IscommitChanged = 'true'
                 Write-Host "Updated repository entry for $RepoName with new commit ID."
-                echo "$statusEnvName=false" >> $Env:GITHUB_ENV
-                Write-Host "$statusEnvName is false."
+                Write-Host "IscommitChanged is false."
             } else {
                 Write-Host "The commit ID for $RepoName is already up to date."
-                echo "$statusEnvName=true" >> $Env:GITHUB_ENV
-                Write-Host "$statusEnvName is true."                
+                Write-Host "IscommitChanged is true."               
             }
         } else {
             # Add new entry if the repository entry does not exist
@@ -461,11 +460,11 @@ function AddOrUpdateRepositoriesJson {
                 repo_name      = $RepoName
                 commit_message = $commitMessage
                 commit_id      = $commitId
+                IscommitChanged = 'true'
             }
             $jsonContent.repositories += $newRepoEntry
             Write-Host "Added new repository entry for $RepoName."
-            echo "$statusEnvName=true" >> $Env:GITHUB_ENV
-            Write-Host "$statusEnvName is true."            
+            Write-Host "IscommitChanged is false."         
         }
 
         # Write updated content back to the file
@@ -479,12 +478,12 @@ function AddOrUpdateRepositoriesJson {
                     repo_name      = $RepoName
                     commit_message = $CommitMessage
                     commit_id      = $CommitId
+                    IscommitChanged = 'true'
                 }
             )
         }
         $initialContent | ConvertTo-Json -Depth 4 | Out-File -FilePath $FilePath -Encoding UTF8
-        echo "$statusEnvName=false" >> $Env:GITHUB_ENV
-        Write-Host "$statusEnvName is false."  
+        Write-Host "IscommitChanged is false." 
     }
 
     # Print the repositories.json content for verification

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -398,12 +398,12 @@ function AddOrUpdateRepositoriesJson {
 
     foreach ($commit in $response) {
         $commitMessage = $commit.commit.message
-        $authorName = $commit.commit.author.name
-        Write-Host "----------------------------"        
+        # $authorName = $commit.commit.author.name
+        # Write-Host "----------------------------"        
         Write-Host "Commit Message: $commitMessage"
-        Write-Host "Author Name: $authorName"
-        Write-Host "Row Number: $rowNumber"
-        Write-Host "----------------------------"
+        # Write-Host "Author Name: $authorName"
+        # Write-Host "Row Number: $rowNumber"
+        # Write-Host "----------------------------"
         $rowNumber++
     }
     #Define the messages to ignore
@@ -437,6 +437,8 @@ function AddOrUpdateRepositoriesJson {
 
     # Check if the file exists
     if (Test-Path $FilePath) {
+
+        Write-Host "File Exists $FilePath ."
         # Read the existing content
         $jsonContent = Get-Content -Path $FilePath -Raw | ConvertFrom-Json
 
@@ -447,6 +449,9 @@ function AddOrUpdateRepositoriesJson {
         # Find the repository entry or create a new one
         $repoEntry = $jsonContent.repositories | Where-Object { $_.repo_name -eq $RepoName }
         
+        Write-Host "Printing before checking where new  Commit ID exists or not "
+        Get-Content $filePath | Write-Host
+
         if ($repoEntry) {
             # Check if the existing commit ID is different from the latest commit ID
             if ($repoEntry.commit_id -ne $commitId) {
@@ -482,6 +487,7 @@ function AddOrUpdateRepositoriesJson {
         $jsonContent | ConvertTo-Json -Depth 4 | Out-File -FilePath $FilePath -Encoding UTF8
     } else {
         # Create a new file with the initial content
+        Write-Host "File not Exists $FilePath .new file is created"        
         $initialContent = @{
             repositories = @(
                 @{
@@ -493,6 +499,7 @@ function AddOrUpdateRepositoriesJson {
         }
         $initialContent | ConvertTo-Json -Depth 4 | Out-File -FilePath $FilePath -Encoding UTF8
         echo "$statusEnvName=true" >> $Env:GITHUB_ENV
+        Write-Host "$statusEnvName is true."  
     }
 
     # Print the repositories.json content for verification

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -449,10 +449,10 @@ function AddOrUpdateRepositoriesJson {
                 $repoEntry.commit_id = $commitId
                 $repoEntry.IscommitChanged = 'true'
                 Write-Host "Updated repository entry for $RepoName with new commit ID."
-                Write-Host "IscommitChanged is false."
+                Write-Host "IscommitChanged is true."
             } else {
                 Write-Host "The commit ID for $RepoName is already up to date."
-                Write-Host "IscommitChanged is true."               
+                Write-Host "IscommitChanged is false."               
             }
         } else {
             # Add new entry if the repository entry does not exist
@@ -464,7 +464,7 @@ function AddOrUpdateRepositoriesJson {
             }
             $jsonContent.repositories += $newRepoEntry
             Write-Host "Added new repository entry for $RepoName."
-            Write-Host "IscommitChanged is false."         
+            Write-Host "IscommitChanged is true."         
         }
 
         # Write updated content back to the file
@@ -483,7 +483,7 @@ function AddOrUpdateRepositoriesJson {
             )
         }
         $initialContent | ConvertTo-Json -Depth 4 | Out-File -FilePath $FilePath -Encoding UTF8
-        Write-Host "IscommitChanged is false." 
+        Write-Host "IscommitChanged is true." 
     }
 
     # Print the repositories.json content for verification

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.355",
+      "PackageVersion": "7.3.356",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -22,22 +22,22 @@
     },
     "TPDMCoreMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.77",
+      "PackageVersion": "7.3.84",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.78",
+      "PackageVersion": "7.3.88",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.{ExtensionVersion}.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.81",
+      "PackageVersion": "7.3.88",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlPopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.{ExtensionVersion}.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.81",
+      "PackageVersion": "7.3.89",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "homograph": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -22,27 +22,27 @@
     },
     "TPDMCoreMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.81",
+      "PackageVersion": "7.3.77",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.85",
+      "PackageVersion": "7.3.78",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.{ExtensionVersion}.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.85",
+      "PackageVersion": "7.3.81",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlPopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.{ExtensionVersion}.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.86",
+      "PackageVersion": "7.3.81",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "homograph": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Homograph.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.88",
+      "PackageVersion": "7.3.64",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "profiles.sample": {
@@ -52,17 +52,17 @@
     },
     "sample": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Sample.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.83",
+      "PackageVersion": "7.3.65",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "tpdm": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.75",
+      "PackageVersion": "7.3.61",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.340",
+      "PackageVersion": "7.3.317",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.317",
+      "PackageVersion": "7.3.343",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -22,22 +22,22 @@
     },
     "TPDMCoreMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.77",
+      "PackageVersion": "7.3.81",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.78",
+      "PackageVersion": "7.3.85",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.{ExtensionVersion}.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.81",
+      "PackageVersion": "7.3.85",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlPopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.{ExtensionVersion}.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.81",
+      "PackageVersion": "7.3.86",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "homograph": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -22,22 +22,22 @@
     },
     "TPDMCoreMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.100",
+      "PackageVersion": "7.3.101",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.104",
+      "PackageVersion": "7.3.105",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.{ExtensionVersion}.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.104",
+      "PackageVersion": "7.3.105",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlPopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.{ExtensionVersion}.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.105",
+      "PackageVersion": "7.3.106",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "homograph": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -2,22 +2,22 @@
   "packages": {
     "EdFiMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.133",
+      "PackageVersion": "7.3.134",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "GrandBend": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.119",
+      "PackageVersion": "7.3.120",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.115",
+      "PackageVersion": "7.3.116",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlPopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.120",
+      "PackageVersion": "7.3.121",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCoreMinimalTemplate": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.339",
+      "PackageVersion": "7.3.340",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -42,7 +42,7 @@
     },
     "homograph": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Homograph.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.119",
+      "PackageVersion": "7.3.120",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "profiles.sample": {
@@ -52,12 +52,12 @@
     },
     "sample": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Sample.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.113",
+      "PackageVersion": "7.3.114",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "tpdm": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.100",
+      "PackageVersion": "7.3.101",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Ods.CodeGen": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.356",
+      "PackageVersion": "7.3.357",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.346",
+      "PackageVersion": "7.3.347",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.357",
+      "PackageVersion": "7.3.416",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.351",
+      "PackageVersion": "7.3.352",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.347",
+      "PackageVersion": "7.3.350",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.317",
+      "PackageVersion": "7.3.338",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -42,7 +42,7 @@
     },
     "homograph": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Homograph.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.109",
+      "PackageVersion": "7.3.119",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "profiles.sample": {
@@ -52,12 +52,12 @@
     },
     "sample": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Sample.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.102",
+      "PackageVersion": "7.3.113",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "tpdm": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.91",
+      "PackageVersion": "7.3.100",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Ods.CodeGen": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -2,22 +2,22 @@
   "packages": {
     "EdFiMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.103",
+      "PackageVersion": "7.3.117",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "GrandBend": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.84",
+      "PackageVersion": "7.3.103",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.87",
+      "PackageVersion": "7.3.99",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlPopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.87",
+      "PackageVersion": "7.3.104",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCoreMinimalTemplate": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -42,7 +42,7 @@
     },
     "homograph": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Homograph.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.64",
+      "PackageVersion": "7.3.88",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "profiles.sample": {
@@ -52,12 +52,12 @@
     },
     "sample": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Sample.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.65",
+      "PackageVersion": "7.3.83",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "tpdm": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.61",
+      "PackageVersion": "7.3.75",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Ods.CodeGen": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.416",
+      "PackageVersion": "7.3.419",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -22,22 +22,22 @@
     },
     "TPDMCoreMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.84",
+      "PackageVersion": "7.3.100",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.88",
+      "PackageVersion": "7.3.104",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.TPDM.Core.{ExtensionVersion}.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.88",
+      "PackageVersion": "7.3.104",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCorePostgreSqlPopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.TPDM.Core.{ExtensionVersion}.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.89",
+      "PackageVersion": "7.3.105",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "homograph": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -2,22 +2,22 @@
   "packages": {
     "EdFiMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.117",
+      "PackageVersion": "7.3.133",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "GrandBend": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.103",
+      "PackageVersion": "7.3.119",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlMinimalTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Minimal.Template.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.99",
+      "PackageVersion": "7.3.115",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "PostgreSqlPopulatedTemplate": {
       "PackageName": "EdFi.Suite3.Ods.Populated.Template.PostgreSQL.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.104",
+      "PackageVersion": "7.3.120",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "TPDMCoreMinimalTemplate": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -42,7 +42,7 @@
     },
     "homograph": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Homograph.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.108",
+      "PackageVersion": "7.3.109",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "profiles.sample": {
@@ -52,12 +52,12 @@
     },
     "sample": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Sample.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.101",
+      "PackageVersion": "7.3.102",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "tpdm": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.90",
+      "PackageVersion": "7.3.91",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Ods.CodeGen": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -42,7 +42,7 @@
     },
     "homograph": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Homograph.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.64",
+      "PackageVersion": "7.3.108",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "profiles.sample": {
@@ -52,12 +52,12 @@
     },
     "sample": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.Sample.1.0.0.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.65",
+      "PackageVersion": "7.3.101",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "tpdm": {
       "PackageName": "EdFi.Suite3.Ods.Extensions.TPDM.Core.{ExtensionVersion}.Standard.{StandardVersion}",
-      "PackageVersion": "7.3.61",
+      "PackageVersion": "7.3.90",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Ods.CodeGen": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.350",
+      "PackageVersion": "7.3.351",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {

--- a/configuration.packages.json
+++ b/configuration.packages.json
@@ -62,7 +62,7 @@
     },
     "EdFi.Ods.CodeGen": {
       "PackageName": "EdFi.Suite3.Ods.CodeGen",
-      "PackageVersion": "7.3.338",
+      "PackageVersion": "7.3.339",
       "PackageSource": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     },
     "EdFi.Db.Deploy": {


### PR DESCRIPTION
Below is a structured breakdown of each use case:

Use Case 1:
Scenario:

A new commit occurs in one of the three repositories (Ed-Fi-ODS, Ed-Fi-ODS-Implementation, or Ed-Fi-Extensions).
The workflow begins by updating the CodeGen package but fails before completing.
Expected Behavior:

In the first run, the workflow updates the CodeGen package version. However, the workflow fails after this update, preventing the completion of other package updates.
Example Workflow Run:

[Failed after updating CodeGen package](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/runs/10517476403/job/29141657598).
Use Case 2:
Scenario:

The workflow is re-triggered after the failure in Use Case 1.
It should skip the CodeGen package update since it was already updated and continue updating the Extensions packages (TPDM, Sample, Homograph).
Expected Behavior:

The workflow should resume from the Extensions package update, bypassing the CodeGen package. However, it fails again after updating the Extensions packages.
Example Workflow Run:

[Failed after updating Extensions packages](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/runs/10517520017/job/29141781325).
Use Case 3:
Scenario:

The workflow is re-triggered after the failure in Use Case 2.
It should skip both the CodeGen and Extensions package updates, resuming with updates to the EdFi.Ods.Minimal.Template, EdFi.Ods.Minimal.Template.PostgreSQL, EdFi.Ods.Populated.Template, and EdFi.Ods.Populated.Template.PostgreSQL packages.
Expected Behavior:

The workflow should skip the already updated CodeGen and Extensions packages, but it fails after attempting to update the Minimal and Populated templates.
Example Workflow Run:

[Failed after updating Minimal and Populated templates](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/runs/10518959780/job/29145570132).
Use Case 4:
Scenario:

The workflow is re-triggered after the failure in Use Case 3.
It should skip the CodeGen, Extensions, and Minimal/Populated template updates and continue with the updates for EdFi.Ods.Minimal.Template.TPDM, EdFi.Ods.Minimal.Template.TPDM.PostgreSQL, EdFi.Ods.Populated.Template.TPDM, and EdFi.Ods.Populated.Template.TPDM.PostgreSQL packages.
Expected Behavior:

The workflow successfully completes by updating the TPDM-related templates without any failures.
Example Workflow Run:

[Successful completion after TPDM package updates](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/runs/10519122224/job/29145994222).
Validation Steps:
Branch Consistency Across Repositories:
Ensure the working branch exists in all three repositories (Ed-Fi-ODS, Ed-Fi-ODS-Implementation, Ed-Fi-Extensions).
Check for Previous Workflow Failures:
Before starting the process, check if there was a failure in the last run. If so, determine whether any packages were updated successfully.
Handling New Commits:
If new commits are detected after a failed workflow, ensure the workflow resumes from where it left off by skipping already updated packages.