### PR TITLE
[ODS-6496] Update Landing Page

### DIFF
--- a/LandingPage/index.css
+++ b/LandingPage/index.css
@@ -5,44 +5,28 @@ The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2
 See the LICENSE and NOTICES files in the project root for more information.
 */
 
-/* centers the progress element */
-#progress {
-  top: 0px;
-  left: 0px;
-  width: 100%;
-  height: 100%;
-  position: fixed;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: transparent;
+.page-title {
+  font-size: 2rem;
 }
 
-/* improve default link hovering */
-a {
-  transition: color 0.5s ease-in;
+.page-title .logo {
+  height: 3.7rem;
 }
 
-a:hover {
-  color: #1f69c0;
-  transition: color 0.1s ease-out;
+.notice {
+  background-color: #ffe484;
+  box-shadow: inset 0 -1px 1px rgba(var(--bs-body-color-rgb), 0.15), 0 0.25rem 1.5rem rgba(255, 255, 255, 0.75);
 }
 
-/* reduces spacing between rows */
-.row {
-  margin-bottom: 5px;
+.version-row {
+  border-bottom: 1px solid #e4e4e4;
 }
 
-/* adds the fade in animation for most elements */
-#cautionTitle,
-.section,
-.col,
-.row,
+.version-row:last-child {
+  border-bottom: initial;
+}
+
 #sections {
-  -webkit-animation: fadein 0.5s ease-out;
-  -moz-animation: fadein 0.5s ease-out;
-  -ms-animation: fadein 0.5s ease-out;
-  -o-animation: fadein 0.5s ease-out;
   animation: fadein 0.5s ease-out;
 }
 
@@ -54,67 +38,4 @@ a:hover {
   to {
     opacity: 1;
   }
-}
-
-@-moz-keyframes fadein {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-@-webkit-keyframes fadein {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-@-ms-keyframes fadein {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-@-o-keyframes fadein {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-#cautionTitle {
-  font-style: italic !important;;
-  color: #3b4151;
-  font-family: sans-serif !important;;
-  font-size: 14px;
-  border-left: 0px;
-  box-sizing: inherit;
-  display: block;
-  margin-block-start: 1em;
-  margin-block-end: 1em;
-  margin-inline-start: 0px;
-  margin-inline-end: 0px;
-  text-align: center !important;;
-}
-
-.wrapper {
-  box-sizing: border-box;
-  margin: 0 auto;
-  max-width: 1460px;
-  padding: 0 20px;
-  width: 100%;
 }

--- a/LandingPage/index.html
+++ b/LandingPage/index.html
@@ -9,7 +9,7 @@ See the LICENSE and NOTICES files in the project root for more information.
 <html lang="en">
 
 <head>
-    <title>Ed-Fi ODS / API Landing Page</title>
+    <title>Ed-Fi API Landing Page</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <meta name="msapplication-TileImage" content="https://www.ed-fi.org/assets/2017/07/cropped-logo-270x270.png">
@@ -17,71 +17,48 @@ See the LICENSE and NOTICES files in the project root for more information.
     <link rel="icon" href="https://www.ed-fi.org/assets/2017/07/cropped-logo-32x32.png" sizes="32x32">
     <link rel="icon" href="https://www.ed-fi.org/assets/2017/07/cropped-logo-192x192.png" sizes="192x192">
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="index.css?refreshcss=1" />
 
-    <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.min.js" rel="preload"></script>
-    <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@3.0.0/dist/fetch.umd.min.js" rel="preload"></script>
-    <script src="https://cdn.jsdelivr.net/npm/semver-lite@0.0.6/dist/semver.js"></script>
-    <script src="index.js" rel="preload"></script>
+    <script type="module" src="index.js"></script>
 </head>
 
 <body>
-    <div class="container">
-        <div id="pageTitle" class="section center-align">
-            <h4 class="valign-wrapper" style="justify-content: center; width: 100%">
-                <img class="responsive-img" src="EdFi-logo-Powered-60.png" alt="Ed-Fi Logo" />
-                <span>ODS / API Landing Page</span>
-            </h4>
-            <h6 id="progressDescription" class="center-align grey-text text-darken-1">Loading...</h6>
-            <div id="errorDescription" class="center-align red-text hide"></div>
+    <div class="container col-lg-6 mt-3">
+        <div class="page-title m-4 d-flex justify-content-center align-items-center">
+            <img class="logo" src="EdFi-logo-Powered-60.png" alt="Ed-Fi Logo" />
+            <span>API Landing Page</span>
         </div>
-        <hr>
-        <div id="cautionTitle" class="valign-wrapper wrapper" style="justify-content: center; width: 100%">
-                        Note: The sandboxes provided here are for interactive documentation and demo purpose only. These
-                        sandboxes are not meant for testing integration and care must be taken not to use real student
-                        data.
-        </div>
-        <hr>
-        <div id="sections" class="row hide"></div>
 
-        <div id="progress">
-            <div class="preloader-wrapper big active">
-                <div class="spinner-layer spinner-blue-only">
-                    <div class="circle-clipper left">
-                        <div class="circle"></div>
-                    </div>
-                    <div class="gap-patch">
-                        <div class="circle"></div>
-                    </div>
-                    <div class="circle-clipper right">
-                        <div class="circle"></div>
-                    </div>
+        <div class="alert alert-warning notice" role="alert">
+            <i class="bi bi-exclamation-triangle"></i>
+            The sandboxes provided here are for interactive documentation and demo purpose only.
+            These sandboxes are not meant for testing integration and care must be taken not to use real student data.
+        </div>
+
+        <div id="sections" class="d-none">
+            <div class="card">
+                <div class="card-body">
+                    <div id="noApisMessage" class="text-center fst-italic d-none">No Ed-Fi APIs were detected.</div>
                 </div>
+            </div>
+        </div>
+
+        <div id="progress" class="position-fixed top-50 start-50 translate-middle">
+            <div class="spinner-border" role="status">
+                <span class="visually-hidden">Loading...</span>
             </div>
         </div>
     </div>
 
-    <template id="sectionTemplate">
-        <div class="col m12 xl8 offset-xl2">
-            <h5 class="blue-text left-align"><strong>Ed-Fi ODS / API Suite {{apiSuite}}</strong></h5>
-            <hr />
-        </div>
-    </template>
-
     <template id="versionTemplate">
-        <div class="version row">
-            <div class="col m6 xl6 green-text text-accent-4 left-align">
-                <strong>{{apiVersion}}</strong>
-            </div>
-            <div class="versionLinks col m6 xl6 right-align blue-text text-darken-3">
-            </div>
+        <div class="py-1">
+            <p class="d-inline m-2">{{apiVersion}}</p>
+            <span class="versionLinks float-end"></span>
         </div>
     </template>
-
-    <template id="apiTemplate">[<a class="" target="_blank" href="{{apiUrl}}">API</a>]&nbsp;&nbsp;</template>
-
-    <template id="docsTemplate">[<a class="" target="_blank" href="{{docsUrl}}">Documentation & Sandbox</a>]</template>
+    <template id="apiLinkTemplate"><a class="m-1" target="_blank" href="{{apiUrl}}">API</a></template>
+    <template id="docsLinkTemplate"><a class="m-1" target="_blank" href="{{docsUrl}}">Documentation & Sandbox</a></template>
 </body>
-
 </html>


### PR DESCRIPTION
Changes included in this PR:
- Changed the probing logic to test against a pre-defined set of version ranges.
- Removed the need to specify the API variants (shared-instance, year-specific, ...) for each API version in the configuration.
- Replaced Materialize with the latest version of Bootstrap.
- Removed the logic related to displaying patch versions and suites.