### PR TITLE
[ODS-6510] Apply SOLID and DRY principles to security/authorization logic (through consolidation of common code)

### DIFF
--- a/Application/EdFi.Ods.Features.OwnershipBasedAuthorization/Security/OwnershipInitializationCreateEntityDecorator.cs
+++ b/Application/EdFi.Ods.Features.OwnershipBasedAuthorization/Security/OwnershipInitializationCreateEntityDecorator.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EdFi.Common;
 using EdFi.Ods.Api.Security.Authorization;
+using EdFi.Ods.Api.Security.Authorization.AuthorizationBasis;
 using EdFi.Ods.Api.Security.Authorization.Filtering;
 using EdFi.Ods.Common.Models.Domain;
 using EdFi.Ods.Common.Repositories;

--- a/Application/EdFi.Ods.Features.OwnershipBasedAuthorization/Security/OwnershipInitializationCreateEntityDecorator.cs
+++ b/Application/EdFi.Ods.Features.OwnershipBasedAuthorization/Security/OwnershipInitializationCreateEntityDecorator.cs
@@ -31,25 +31,15 @@ namespace EdFi.Ods.Features.OwnershipBasedAuthorization.Security
         /// </summary>
         /// <param name="next">The decorated instance for which authorization is being performed.</param>
         /// <param name="authorizationContextProvider">Provides access to the authorization context, such as the resource and action.</param>
-        /// <param name="authorizationFilteringProvider">The component capable of authorizing the request, given necessary context.</param>
-        /// <param name="authorizationBasisMetadataSelector"></param>
         /// <param name="apiClientContextProvider"></param>
-        /// <param name="dataManagementResourceContextProvider"></param>
         /// <param name="entityAuthorizer"></param>
         public OwnershipInitializationCreateEntityDecorator(
             ICreateEntity<TEntity> next,
             IAuthorizationContextProvider authorizationContextProvider,
-            IAuthorizationFilteringProvider authorizationFilteringProvider,
-            IAuthorizationBasisMetadataSelector authorizationBasisMetadataSelector,
             IApiClientContextProvider apiClientContextProvider,
-            IContextProvider<DataManagementResourceContext> dataManagementResourceContextProvider,
             IEntityAuthorizer entityAuthorizer)
             : base(
                 authorizationContextProvider,
-                authorizationFilteringProvider,
-                authorizationBasisMetadataSelector,
-                apiClientContextProvider,
-                dataManagementResourceContextProvider,
                 entityAuthorizer)
         {
             _next = Preconditions.ThrowIfNull(next, nameof(next));


### PR DESCRIPTION
The main focus of this refactoring was to apply SOLID and DRY principles to the existing authorization code to make it easier to understand and (more importantly) unit testable. The previous code made use of many bits of contextual information through the execution path for authorization. This branch introduces a `DataManagementAuthorizationPlan` class (built using the new `IDataManagementAuthorizationPlanFactory`) that consolidates the gathering of all this contextual information in one place, and as late as possible in the authorization processing. The result is the removal of many "context" dependencies from many classes.

A second focus decomposes two large classes into testable units: `AuthorizationBasisMetadataSelector` and `EntityAuthorizer`. These two classes had way too many responsibilities. Those responsibilities have been shifted to new classes which are now located in the _AuthorizationBasis_ and _EntityAuthorization_ folders, as shown here:
![image](https://github.com/user-attachments/assets/bc279f41-bf6c-4f27-8812-765595a07eec)

In addition, a full set of unit tests have been created for the new classes, and are located in similarly named folders in the unit tests project:
![image](https://github.com/user-attachments/assets/fe4a9ff1-1b7e-44e2-99d8-3fc4e81a98c2)

Here is a view from JetBrains Rider showing the passing unit tests:
![image](https://github.com/user-attachments/assets/1aa862ac-d3db-4692-85d8-ec08ee8c85c4)

... and the code coverage provided by the unit tests:
![image](https://github.com/user-attachments/assets/cd45b711-187c-424f-aff2-9c5d34aa29d8)

It is worth noting that the `EntityAuthorizationQueryExecutor` class uses the NHibernate SessionFactory to obtain the connection, which is returned as a `DbConnection` instance. Unfortunately, it is non-trivial to try and mock these for unit testing purposes and so the coverage will have to rely on the many integration tests that we have in the solution.