### PR TITLE
[ODS-6615] API only allows tenant1's profiles when different profiles are set up for different tenants

### DIFF
--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/EdFi.Ods.Api.IntegrationTestHarness.csproj
@@ -23,6 +23,14 @@
     <None Update="AdminCredential.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="..\..\..\Ed-Fi-ODS\Application\EdFi.Ods.Profiles.Test\ProfilesTenant1.xml">
+      <Link>ProfilesTenant1.xml</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\Ed-Fi-ODS\Application\EdFi.Ods.Profiles.Test\ProfilesTenant2.xml">
+      <Link>ProfilesTenant2.xml</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\..\Plugin\**" LinkBase="Plugin\" Exclude="..\..\Plugin\*.ps1;..\..\Plugin\**\*.nupkg" CopyToPublishDirectory="Always" CopyToOutputDirectory="Never" />
     <Content Include="..\..\..\Ed-Fi-ODS\Application\EdFi.Ods.Profiles.Test\Profiles.xml" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />
     <Content Include="..\..\..\Ed-Fi-ODS\Application\EdFi.Ods.Profiles.Test\InvalidProfiles.xml" CopyToPublishDirectory="Always" CopyToOutputDirectory="Always" />

--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/Migrations/ISecurityDatabaseConnectionStringCatalog.cs
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/Migrations/ISecurityDatabaseConnectionStringCatalog.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.Ods.Api.IntegrationTestHarness.Migrations;
+
+/// <summary>
+/// Defines a method for obtaining connection strings for all the EdFi_Security databases available in the deployment environment. 
+/// </summary>
+public interface ISecurityDatabaseConnectionStringCatalog
+{
+    /// <summary>
+    /// Gets the connection strings for all the EdFi_Security databases available in the deployment environment.
+    /// </summary>
+    /// <returns>The connection strings for EdFi_Security databases.</returns>
+    string[] GetConnectionStrings();
+}

--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/Migrations/MultiTenantSecurityDatabaseConnectionStringCatalog.cs
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/Migrations/MultiTenantSecurityDatabaseConnectionStringCatalog.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using EdFi.Ods.Api.Middleware;
+using EdFi.Ods.Common.Configuration;
+using EdFi.Ods.Common.Context;
+using EdFi.Security.DataAccess.Providers;
+
+namespace EdFi.Ods.Api.IntegrationTestHarness.Migrations;
+
+/// <summary>
+/// Implements an <see cref="ISecurityDatabaseConnectionStringCatalog" /> that returns a connection string
+/// for each of the tenant-specific EdFi_Security databases in a multitenant deployment.
+/// </summary>
+public class MultiTenantSecurityDatabaseConnectionStringCatalog : ISecurityDatabaseConnectionStringCatalog
+{
+    private readonly ISecurityDatabaseConnectionStringProvider _securityConnectionStringProvider;
+    private readonly IContextProvider<TenantConfiguration> _tenantConfigurationContextProvider;
+    private readonly ITenantConfigurationMapProvider _tenantConfigurationMapProvider;
+
+    public MultiTenantSecurityDatabaseConnectionStringCatalog(
+        ISecurityDatabaseConnectionStringProvider securityConnectionStringProvider,
+        ITenantConfigurationMapProvider tenantConfigurationMapProvider,
+        IContextProvider<TenantConfiguration> tenantConfigurationContextProvider)
+    {
+        _securityConnectionStringProvider = securityConnectionStringProvider;
+        _tenantConfigurationMapProvider = tenantConfigurationMapProvider;
+        _tenantConfigurationContextProvider = tenantConfigurationContextProvider;
+    }
+
+    /// <summary>
+    /// Gets a connection string for each of the tenant-specific EdFi_Security databases in a multitenant deployment.
+    /// </summary>
+    /// <returns></returns>
+    public string[] GetConnectionStrings()
+    {
+        List<string> connectionStrings = new();
+
+        foreach (var tenantConfigurationMap in _tenantConfigurationMapProvider.GetMap())
+        {
+            _tenantConfigurationContextProvider.Set(tenantConfigurationMap.Value);
+            connectionStrings.Add(_securityConnectionStringProvider.GetConnectionString());
+            _tenantConfigurationContextProvider.Set(null);
+        }
+
+        return connectionStrings.ToArray();
+    }
+}

--- a/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
+++ b/Application/EdFi.Ods.Api.IntegrationTestHarness/UpdateAdminDatabaseTask.cs
@@ -26,7 +26,7 @@ using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Formatting = Newtonsoft.Json.Formatting;
-using TenantConfiguration = EdFi.Ods.Api.Middleware.TenantConfiguration;
+using TenantConfiguration = EdFi.Ods.Common.Configuration.TenantConfiguration;
 
 namespace EdFi.Ods.Api.IntegrationTestHarness
 {
@@ -201,8 +201,13 @@ namespace EdFi.Ods.Api.IntegrationTestHarness
                 });
 
             // Add Profiles
-            var profileFilenames = Directory.GetFiles(Directory.GetParent(AppContext.BaseDirectory).FullName, "*Profiles.xml");
+            string[] profileFilenames = Directory.GetFiles(Directory.GetParent(AppContext.BaseDirectory).FullName, $"*Profiles.xml");
 
+            if(!string.IsNullOrEmpty(tenantIdentifier))
+            {
+                profileFilenames = profileFilenames.Union(Directory.GetFiles(Directory.GetParent(AppContext.BaseDirectory).FullName, $"*Profiles{tenantIdentifier}.xml")).ToArray();
+            }
+            
             var profileDefinitionByName = new Dictionary<string, XmlNode>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var profileFilename in profileFilenames)


### PR DESCRIPTION
[[ODS-6481] Update package and github action versions (#1108) are set up for different tenants (#1209)](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/commit/f688905ca6d2cd77fcb21e296451d9c145de2818)

[ODS-6481]: https://edfi.atlassian.net/browse/ODS-6481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ