### PR TITLE
DATASTD-2471 Delete Items On SEOA Previously Marked for Deprecation

### DIFF
--- a/Extensions/Sample/SampleMetaEd/Association/StudentEducationOrganizationAssociationExtension.metaed
+++ b/Extensions/Sample/SampleMetaEd/Association/StudentEducationOrganizationAssociationExtension.metaed
@@ -4,9 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 Association EdFi.StudentEducationOrganizationAssociation additions
-    common extension EdFi.Address
-        documentation "The set of elements that describes an address, including the street address, city, state, and ZIP code."
-        is optional collection
     common extension EdFi.StudentCharacteristic
         documentation "Reflects important characteristics of the student's home situation:
         Displaced Homemaker, Immigrant, Migratory, Military Parent, Pregnant Teen, Single Parent, and Unaccompanied Youth."


### PR DESCRIPTION
Removed the Address common in an attempt to correct the issue on this [PR](https://github.com/Ed-Fi-Closed/Ed-Fi-Model/pull/154).

`{"level":"error","message":"  'common extension' is invalid for property Address on Association Extension StudentEducationOrganizationAssociation. 'common extension' is only valid for referencing common properties with the same declaration as in the base entity.  /home/runner/work/Ed-Fi-Model/Ed-Fi-Model/MetaEdExtensionSource/Association/StudentEducationOrganizationAssociationExtension.metaed (7:5)"}`