### PR TITLE
[ODS-6687] Release ODS API v7.3 patch2

### DIFF
--- a/.github/workflows/Publish to Azure Artifacts.yml
+++ b/.github/workflows/Publish to Azure Artifacts.yml
@@ -34,9 +34,57 @@ env:
 
 jobs:
   FindStandardAndExtensionVersions:
-    uses: Ed-Fi-Alliance-OSS/Ed-Fi-ODS/.github/workflows/Find Standard and Extension Versions.yml@874b608a0f3a14243e0035dd1222169fafcbe8d3
-    with:
-      calling_branch: ${{ github.head_ref || github.ref_name }}
+      runs-on: ubuntu-latest    
+      outputs:
+        StandardVersions: ${{ steps.Set_StandardVersions.outputs.StandardVersions }}
+        ExtensionVersions: ${{ steps.Set_ExtensionVersions.outputs.ExtensionVersions }}
+      steps:
+      - name: Checkout Ed-Fi-ODS-Implementation
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+        with:
+            repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
+            path: Ed-Fi-ODS-Implementation/   
+      - name: Is pull request branch exists in Ed-Fi-ODS-Implementation
+        working-directory: ./Ed-Fi-ODS-Implementation/
+        shell: pwsh
+        run: |
+          .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../"    
+      - name: Checkout Ed-Fi-Extensions
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+        with:
+            repository: Ed-Fi-Alliance-OSS/Ed-Fi-Extensions
+            path: Ed-Fi-Extensions/
+      - name: Is pull request branch exists in Ed-Fi-Extension
+        working-directory: ./Ed-Fi-ODS-Implementation/
+        shell: pwsh
+        run: |
+          .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-Extensions"  
+      - name: Checkout Ed-Fi-ODS
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2
+        with:
+            repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS
+            path: Ed-Fi-ODS/
+      - name: Is pull request branch exists in Ed-Fi-ODS
+        working-directory: ./Ed-Fi-ODS-Implementation/
+        shell: pwsh
+        run: |
+          .\build.githubactions.ps1 CheckoutBranch -RelativeRepoPath "../Ed-Fi-ODS"          
+      - name: Set StandardVersions
+        id: Set_StandardVersions
+        working-directory: ./Ed-Fi-ODS-Implementation/
+        run: |
+          $output = .\build.githubactions.ps1 StandardVersions -ProjectFile "$env:GITHUB_WORKSPACE/Ed-Fi-ODS/Application/EdFi.Ods.Standard/EdFi.Ods.Standard.csproj"
+          echo "StandardVersions=$output" >> $env:GITHUB_OUTPUT
+          Write-host "StandardVersions is  $output"
+        shell: pwsh
+      - name: Set ExtensionVersions
+        id: Set_ExtensionVersions
+        working-directory: ./Ed-Fi-ODS-Implementation/  
+        run: |
+          $output = .\build.githubactions.ps1 ExtensionVersions -ProjectFile "$env:GITHUB_WORKSPACE/Ed-Fi-Extensions/Extensions/EdFi.Ods.Extensions.TPDM/EdFi.Ods.Extensions.TPDM.csproj"
+          echo "ExtensionVersions=$output" >> $env:GITHUB_OUTPUT
+          Write-host "ExtensionVersions is  $output"
+        shell: pwsh
       
   build:
 


### PR DESCRIPTION
This change will run the FindStandardAndExtensionVersions from b-v7.3-patch1 branch instead of main , so that it will have only 4.0.0 and 5.2.0 

Currently failing now here with 6.0.0 also
https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation/actions/runs/17549936250/job/49839828222