### PR TITLE
[ODS-6709]  EdFi.Suite3.RestApi.Databases Binary Installation CodeFix

### DIFF
--- a/logistics/scripts/modules/packaging/create-package.psm1
+++ b/logistics/scripts/modules/packaging/create-package.psm1
@@ -139,6 +139,7 @@ function New-Package {
     $parameters = @()
 
     $parameters += "-p:NuspecFile=$($PackageDefinitionFile)"
+    $parameters += "-p:NoDefaultExcludes=true" # Include .nupkg files in the package
     $parameters += "--output"
     $parameters += $OutputDirectory
     $parameters += "--no-build"

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -81,7 +81,7 @@ function Install-DotNetTool {
         [string] $Path,
         [string] $Name,
         [string] $Version,
-        [string] $Source = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+        [string[]] $Source = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
     )
 
     $installedVersion = (Get-DotNetTool $Path $Name).Version
@@ -97,10 +97,22 @@ function Install-DotNetTool {
         Uninstall-DotNetTool $Path $Name $installedVersion
     }
 
-    Write-Host "Installing $Name version $Version to $Path"
-    Write-Host -ForegroundColor Magenta "& dotnet tool install $Name --version $Version --tool-path $Path --add-source $Source  --no-cache"
+    $arguments = @(
+        $Name, 
+        "--version", $Version, 
+        "--tool-path", $Path, 
+        "--no-cache"
+    )
 
-    & dotnet tool install $Name --version $Version --tool-path $Path --add-source $Source  --no-cache
+    # Add each source as a separate --add-source argument
+    foreach ($src in $Source) {
+        $arguments += @("--add-source", $src)
+    }
+
+    Write-Host "Installing $Name version $Version to $Path"
+    Write-Host -ForegroundColor Magenta "& dotnet tool install $arguments"
+
+    & dotnet tool install $arguments
 }
 
 function Install-ToolDbDeploy {


### PR DESCRIPTION
<img width="856" height="585" alt="image" src="https://github.com/user-attachments/assets/194c95d6-bbdc-4fc6-8e22-7fe9957bb9dd" />
builds are updated to run on ubuntu instead of windows. This now packs the DbDeploy package for Linux env. and doesn’t work in Windows. So It requires this code change  .  Currently now database PowerShell Installer to pack dbDeploy .nupkg instead of executable 


Tested with EdFi.Suite3.RestApi.Databases.Standard.5.0.0.7.1.3892