### PR TITLE
[ODS-6837] Remove lingering .NET 8 references after migration to .NET 10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <!-- ASP.NET Core Packages -->
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="10.0.0" />
     <!-- Health Check Packages -->
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />

--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -262,7 +262,7 @@ function InstallCredentialHandler {
 
     $downloadPath = Join-Path ([IO.Path]::GetTempPath()) 'cred-provider.zip'
     
-    $credProviderUrl = 'https://github.com/microsoft/artifacts-credprovider/releases/download/v1.4.1/Microsoft.Net6.NuGet.CredentialProvider.zip'
+    $credProviderUrl = 'https://github.com/microsoft/artifacts-credprovider/releases/download/v2.0.1/Microsoft.Net8.NuGet.CredentialProvider.zip'
     Write-Host "Downloading artifacts-credprovider from $credProviderUrl ..."
     $webClient = New-Object System.Net.WebClient
     $webClient.DownloadFile($credProviderUrl, $downloadPath)

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -173,7 +173,7 @@ function Test-DotNetCore {
     param (
         [Parameter()]
         [int]
-        $RequiredMajor = 8,
+        $RequiredMajor = 10,
         [Parameter()]
         [int]
         $RequiredMinor = 0


### PR DESCRIPTION
- Update Test-DotNetCore default required major version from 8 to 10
- Upgrade the NuGet artifacts credential provider from v1.4.1/Net6 to v2.0.1/Net8 (.NET 6 is EOL; no Net10 variant exists yet)
- Bump Microsoft.Extensions.Logging.Log4Net.AspNetCore from 8.0.0 to 10.0.0, which adds an explicit net10.0 target with matching Microsoft.Extensions.* 10.0.0 dependencies.