### PR TITLE
[ODS-6838] Update Docker Image Build

### DIFF
--- a/Docker/ods-api-bulk-load-console/alpine/Dockerfile
+++ b/Docker/ods-api-bulk-load-console/alpine/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # SDK image used to install dotnet tool. Runtime image do not have 'dotnet tools' installed
-FROM mcr.microsoft.com/dotnet/sdk:10.0.200-alpine3.23@sha256:a0116e63beedf9197c3d491eb224aea9ae7d1692079eda9eebe2809f06d580e3 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:10.0.203-alpine3.23@sha256:0191ff386e93923edf795d363ea0ae0669ce467ada4010b370644b670fa495c1 AS builder
 
 ARG BULKLOAD_VERSION
 
@@ -14,7 +14,7 @@ RUN dotnet tool install -g \
     rm -f /root/.dotnet/tools/.store/edfi.suite3.bulkloadclient.console/$BULKLOAD_VERSION/edfi.suite3.bulkloadclient.console/$BULKLOAD_VERSION/tools/net10.0/any/log4net.config
 
 # Smaller image
-FROM mcr.microsoft.com/dotnet/runtime:10.0.4-alpine3.23@sha256:051a1ec764d16c141f029a3ff90d81bd541c6cb51d29b5416688ff5336037be1
+FROM mcr.microsoft.com/dotnet/runtime:10.0.7-alpine3.23@sha256:405a4e86f50ab5fd78c65bab461499913088d1702da4faf6236426653cc052c4
 RUN apk --upgrade --no-cache add gettext=~0 bash=~5 && \
     addgroup -S edfi && adduser -S edfi -G edfi
 

--- a/Docker/ods-api-db-admin/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-db-admin/alpine/pgsql/Dockerfile
@@ -8,7 +8,7 @@ FROM postgres:16.13-alpine3.23@sha256:4e6e670bb069649261c9c18031f0aded7bb249a5b6
 RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7
 
 # Workaround to fix false positive CVEs using gosu
-FROM golang:1.26.1 AS gosubuilder
+FROM golang:1.26.2 AS gosubuilder
 ENV GOSU_VERSION=1.17
 WORKDIR /go/src/github.com/tianon
 RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION

--- a/Docker/ods-api-db-admin/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-db-admin/alpine/pgsql/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Base image with additional packages
-FROM postgres:16.13-alpine3.23@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416 AS base
+FROM postgres:16.13-alpine3.23@sha256:4e6e670bb069649261c9c18031f0aded7bb249a5b6664ddec29c013a89310d50 AS base
 RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7
 
 # Workaround to fix false positive CVEs using gosu

--- a/Docker/ods-api-db-ods-minimal/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-db-ods-minimal/alpine/pgsql/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 nodejs=~24 npm=~11 && \
     npm install -g semver@7
 
 # Workaround to fix false positive CVEs using gosu
-FROM golang:1.26.1 AS gosubuilder
+FROM golang:1.26.2 AS gosubuilder
 ENV GOSU_VERSION=1.17
 WORKDIR /go/src/github.com/tianon
 RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION

--- a/Docker/ods-api-db-ods-minimal/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-db-ods-minimal/alpine/pgsql/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Base image with additional packages
-FROM postgres:16.13-alpine3.23@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416 AS base
+FROM postgres:16.13-alpine3.23@sha256:4e6e670bb069649261c9c18031f0aded7bb249a5b6664ddec29c013a89310d50 AS base
 RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 nodejs=~24 npm=~11 && \
     npm install -g semver@7
 

--- a/Docker/ods-api-db-ods-sandbox/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-db-ods-sandbox/alpine/pgsql/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 nodejs=~24 npm=~11 && \
     npm install -g semver@7
 
 # Workaround to fix false positive CVEs using gosu
-FROM golang:1.26.1 AS gosubuilder
+FROM golang:1.26.2 AS gosubuilder
 ENV GOSU_VERSION=1.17
 WORKDIR /go/src/github.com/tianon
 RUN git clone https://github.com/tianon/gosu.git --branch $GOSU_VERSION

--- a/Docker/ods-api-db-ods-sandbox/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-db-ods-sandbox/alpine/pgsql/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Base image with additional packages
-FROM postgres:16.13-alpine3.23@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416 AS base
+FROM postgres:16.13-alpine3.23@sha256:4e6e670bb069649261c9c18031f0aded7bb249a5b6664ddec29c013a89310d50 AS base
 RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 nodejs=~24 npm=~11 && \
     npm install -g semver@7
 

--- a/Docker/ods-api-swaggerui/alpine/Dockerfile
+++ b/Docker/ods-api-swaggerui/alpine/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Base image with additional packages
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.7-alpine3.23@sha256:60eb031b554df75a4b9f358290a2fa15d8961a3bc79b47bb34a00e31f7b78c69 AS base
 RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 && \
     addgroup -S edfi && adduser -S edfi -G edfi
 

--- a/Docker/ods-api-web-api/alpine/mssql/Dockerfile
+++ b/Docker/ods-api-web-api/alpine/mssql/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Base image with additional packages
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.7-alpine3.23@sha256:60eb031b554df75a4b9f358290a2fa15d8961a3bc79b47bb34a00e31f7b78c69 AS base
 RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 curl=~8 && \
     addgroup -S edfi && adduser -S edfi -G edfi
 

--- a/Docker/ods-api-web-api/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-web-api/alpine/pgsql/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Base image with additional packages
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.7-alpine3.23@sha256:60eb031b554df75a4b9f358290a2fa15d8961a3bc79b47bb34a00e31f7b78c69 AS base
 RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 && \
     addgroup -S edfi && adduser -S edfi -G edfi
 

--- a/Docker/ods-api-web-sandbox-admin/alpine/mssql/Dockerfile
+++ b/Docker/ods-api-web-sandbox-admin/alpine/mssql/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Base image with additional packages
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.7-alpine3.23@sha256:60eb031b554df75a4b9f358290a2fa15d8961a3bc79b47bb34a00e31f7b78c69 AS base
 RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 curl=~8 && \
     addgroup -S edfi && adduser -S edfi -G edfi
 

--- a/Docker/ods-api-web-sandbox-admin/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-web-sandbox-admin/alpine/pgsql/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Base image with additional packages
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.7-alpine3.23@sha256:60eb031b554df75a4b9f358290a2fa15d8961a3bc79b47bb34a00e31f7b78c69 AS base
 RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 && \
     addgroup -S edfi && adduser -S edfi -G edfi
 

--- a/logistics/ods-postgresql/docker-compose.yml
+++ b/logistics/ods-postgresql/docker-compose.yml
@@ -8,7 +8,7 @@ version: '3'
 services:
   db:
     container_name: ODS-PostgreSQL
-    image: postgres:16.13-alpine3.23@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416
+    image: postgres:16.13-alpine3.23@sha256:4e6e670bb069649261c9c18031f0aded7bb249a5b6664ddec29c013a89310d50
     restart: always
     environment:
       # The default connection strings when using 'initdev -Engine PostgreSql' don't include a password, 


### PR DESCRIPTION
Summary
- Bump pinned .NET SDK / runtime / aspnet Alpine base images from 10.0.4/10.0.200 → 10.0.7/10.0.203 across all ODS API Docker images.
- Refresh SHA256 digest for postgres:16.13-alpine3.23 across the three DB Dockerfiles and the local docker-compose.yml (tag unchanged, digest updated to track the upstream rebuild).
  
 - Pulls in the latest upstream patches for the .NET 10 Alpine images and the rebuilt Postgres 16.13 Alpine image, continuing the vulnerability-remediation work tracked under ODS-6812.
  
 Test plan
 - "Analyze docker images" workflow passes (no new HIGH/CRITICAL findings on the new digests)
 - "Docker Test" / image-bulid workflows succeed
 - Local: docker compose -f logistics/ods-postgresql/docker-compose.yml up starts cleanly