### PR TITLE
[ODS-6841] Docker images Fixed krb5 error when token requested

### DIFF
--- a/Docker/ods-api-web-api/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-web-api/alpine/pgsql/Dockerfile
@@ -5,7 +5,7 @@
 
 # Base image with additional packages
 FROM mcr.microsoft.com/dotnet/aspnet:10.0.7-alpine3.23@sha256:60eb031b554df75a4b9f358290a2fa15d8961a3bc79b47bb34a00e31f7b78c69 AS base
-RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 && \
+RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 krb5-libs && \
     addgroup -S edfi && adduser -S edfi -G edfi
 
 # Start a new layer so that the above layer can be cached

--- a/Docker/ods-api-web-api/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-web-api/alpine/pgsql/Dockerfile
@@ -5,7 +5,7 @@
 
 # Base image with additional packages
 FROM mcr.microsoft.com/dotnet/aspnet:10.0.7-alpine3.23@sha256:60eb031b554df75a4b9f358290a2fa15d8961a3bc79b47bb34a00e31f7b78c69 AS base
-RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 krb5-libs && \
+RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 krb5-libs=~1.22 && \
     addgroup -S edfi && adduser -S edfi -G edfi
 
 # Start a new layer so that the above layer can be cached

--- a/Docker/ods-api-web-sandbox-admin/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-web-sandbox-admin/alpine/pgsql/Dockerfile
@@ -5,7 +5,7 @@
 
 # Base image with additional packages
 FROM mcr.microsoft.com/dotnet/aspnet:10.0.7-alpine3.23@sha256:60eb031b554df75a4b9f358290a2fa15d8961a3bc79b47bb34a00e31f7b78c69 AS base
-RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 && \
+RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 krb5-libs && \
     addgroup -S edfi && adduser -S edfi -G edfi
 
 # Start a new layer so that the above layer can be cached

--- a/Docker/ods-api-web-sandbox-admin/alpine/pgsql/Dockerfile
+++ b/Docker/ods-api-web-sandbox-admin/alpine/pgsql/Dockerfile
@@ -5,7 +5,7 @@
 
 # Base image with additional packages
 FROM mcr.microsoft.com/dotnet/aspnet:10.0.7-alpine3.23@sha256:60eb031b554df75a4b9f358290a2fa15d8961a3bc79b47bb34a00e31f7b78c69 AS base
-RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 krb5-libs && \
+RUN apk --upgrade --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~76 krb5-libs=~1.22 && \
     addgroup -S edfi && adduser -S edfi -G edfi
 
 # Start a new layer so that the above layer can be cached


### PR DESCRIPTION
### Summary

-   Npgsql probes libgssapi_krb5.so.2 during connection setup (auth method negotiation), even when the connection string uses plain username/password.

```
  Cannot load library libgssapi_krb5.so.2
  Error: Error loading shared library libgssapi_krb5.so.2: No such file or directory
```

-   Install the Alpine package krb5-libs (which provides libgssapi_krb5.so.2) in the base stage of both Alpine pgsql Dockerfiles fixes the issue