### PR TITLE
[ODS-6842] Remove redundant --add-source from dotnet tool install

### DIFF
--- a/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
+++ b/Application/SolutionScripts/InitializeDevelopmentEnvironment.psm1
@@ -523,7 +523,6 @@ function Install-DbDeploy {
         $parameters = @{
             Name    = $packageSettings.packageName
             Version = $packageSettings.packageVersion
-            Source  = $packageSettings.packageSource
         }
         if ([string]::IsNullOrWhiteSpace($parameters.Path)) { $parameters.Path = $toolsPath }
         Install-DotNetTool @parameters
@@ -538,7 +537,6 @@ function Install-CodeGenUtility {
         $parameters = @{
             Name    = $packageSettings.packageName
             Version = $packageSettings.packageVersion
-            Source  = $packageSettings.packageSource
         }
         if ([string]::IsNullOrWhiteSpace($parameters.Path)) { $parameters.Path = $toolsPath }
         Install-DotNetTool @parameters

--- a/logistics/scripts/modules/tools/ToolsHelper.psm1
+++ b/logistics/scripts/modules/tools/ToolsHelper.psm1
@@ -81,7 +81,7 @@ function Install-DotNetTool {
         [string] $Path,
         [string] $Name,
         [string] $Version,
-        [string[]] $Source = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+        [string[]] $Source = @()
     )
 
     $installedVersion = (Get-DotNetTool $Path $Name).Version


### PR DESCRIPTION
 dotnet SDK 10.0.300 (added to ubuntu-24.04 runner on May 13 2026) now strictly enforces that --add-source cannot be combined with packageSourceMapping. The Azure Artifacts feed is already declared in NuGet.Config with packageSourceMapping routing EdFi.* packages there, so passing Source from configuration.packages.json is redundant.
| When          | What happened |
|---------------|---------------|
| Jan 2026      | `packageSourceMapping` added to `NuGet.config` (commit 1cee4d8c) |
| Jan–May 13    | Builds passed — .NET SDK ≤ 10.0.201 allowed `--add-source` with mapping |
| May 13, 2026  | GitHub runner updated (ubuntu-24.04 → image 20260513.135.3, SDK 10.0.300) |
| May 14 onward | Builds fail — SDK 10.0.300 enforces rule: `--add-source` cannot be used with `packageSourceMapping` |
